### PR TITLE
Update installation to use bun global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The core idea: **tmux is the collaboration layer**. AI agents create and manage 
 ## Quick Start
 
 ```bash
+# 0. Install globally with bun
+bun install -g @automagik/genie
+
 # 1. Install prerequisites (tmux, bun)
 genie install
 
@@ -468,23 +471,13 @@ term read my-session -n 10 --json
 ## Installation
 
 ```bash
-# 1. Check prerequisites
-genie install
+# Install globally with bun
+bun install -g @automagik/genie
 
-# 2. Build
-bun install
-bun run build
-
-# 3. Symlink to PATH
-ln -s $(pwd)/dist/genie.js ~/.local/bin/genie
-ln -s $(pwd)/dist/term.js ~/.local/bin/term
-ln -s $(pwd)/dist/claudio.js ~/.local/bin/claudio
-
-# 4. Configure hooks
-genie setup
-
-# 5. Install hooks into Claude Code
-genie hooks install
+# Then run setup
+genie install   # Check/install prerequisites (tmux, bun)
+genie setup     # Configure hooks interactively
+genie hooks install  # Install hooks into Claude Code
 ```
 
 Requirements: Bun, tmux

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automagik/genie",
   "version": "0.260201.2219",
-  "description": "Dual CLI: claudio (Claude profiles) + term (terminal orchestration)",
+  "description": "Collaborative terminal toolkit for human + AI workflows",
   "type": "module",
   "bin": {
     "claudio": "./dist/claudio.js",

--- a/src/claudio.ts
+++ b/src/claudio.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander';
+import { VERSION } from './lib/version.js';
 import { setupCommand } from './commands/setup.js';
 import { launchProfile, launchDefaultProfile, type LaunchOptions } from './commands/launch.js';
 import {
@@ -17,7 +18,7 @@ const program = new Command();
 program
   .name('claudio')
   .description('Launch Claude Code with custom LLM router profiles')
-  .version('0.2.0')
+  .version(VERSION)
   .option('--hooks <presets>', 'Override hooks (comma-separated: collaborative,supervised,sandboxed,audited)')
   .option('--no-hooks', 'Disable all hooks');
 

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander';
+import { VERSION } from './lib/version.js';
 import { installCommand } from './genie-commands/install.js';
 import { setupCommand, quickSetupCommand } from './genie-commands/setup.js';
 import { updateCommand } from './genie-commands/update.js';
@@ -21,7 +22,7 @@ const program = new Command();
 program
   .name('genie')
   .description('Genie CLI - Setup and utilities for AI-assisted development')
-  .version('0.1.0');
+  .version(VERSION);
 
 // Install command - check/install prerequisites
 program

--- a/src/term.ts
+++ b/src/term.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from 'commander';
+import { VERSION } from './lib/version.js';
 import * as newCmd from './term-commands/new.js';
 import * as lsCmd from './term-commands/ls.js';
 import * as attachCmd from './term-commands/attach.js';
@@ -23,7 +24,7 @@ program
 
 Workflow: new → exec → read → rm
 Full control: window new/ls/rm, pane ls/rm, split, status`)
-  .version('0.2.0');
+  .version(VERSION);
 
 // Session management
 program


### PR DESCRIPTION
## Summary

- Update README Quick Start and Installation sections to use `bun install -g @automagik/genie` instead of manual build/symlink
- Update package.json description to be clearer: "Collaborative terminal toolkit for human + AI workflows"
- Use shared VERSION constant in CLI entry points

## Test plan

- [ ] Merge to main to trigger auto-publish workflow
- [ ] Test installation: `bun install -g @automagik/genie`
- [ ] Verify commands work: `genie --help`, `term --help`, `claudio --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)