### PR TITLE
feat(term): add --skill option to work command with auto-detect

### DIFF
--- a/src/term.ts
+++ b/src/term.ts
@@ -301,6 +301,7 @@ program
   .option('--focus', 'Focus the worker pane after spawning')
   .option('-p, --prompt <message>', 'Custom initial prompt')
   .option('--no-resume', 'Start fresh session even if previous exists')
+  .option('--skill <name>', 'Skill to invoke (auto-detects "forge" if wish.md exists)')
   .action(async (target: string, options: workCmd.WorkOptions) => {
     await workCmd.workCommand(target, options);
   });


### PR DESCRIPTION
## Summary
- Add `--skill <name>` option to `term work` command for explicit skill invocation
- Auto-detect and use `forge` skill when `.genie/wishes/<task-id>/wish.md` exists
- Add `wishFileExists` helper function to check for wish documents

## Test plan
- [ ] Run `term work <task-id>` on a task with existing wish.md - should auto-invoke `/forge`
- [ ] Run `term work <task-id>` on a task without wish.md - should use default prompt
- [ ] Run `term work <task-id> --skill brainstorm` - should override auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)