### PR TITLE
chore: bump version to 0.260203.0637 (wish-4 complete)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "0.260203.0508",
+  "version": "0.260203.0637",
   "description": "Collaborative terminal toolkit for human + AI workflows",
   "type": "module",
   "bin": {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,5 +1,5 @@
 // Runtime version (baked in at build time)
-export const VERSION = '0.260203.0508';
+export const VERSION = '0.260203.0637';
 
 // Generate version string from current datetime
 // Format: 0.YYMMDD.HHMM (e.g., 0.260201.1430 = Feb 1, 2026 at 14:30)


### PR DESCRIPTION
## Summary

- Bumps version to 0.260203.0637 after completing wish-4 QA sweep

The core wish-4 implementation (already in main) included:
- `term update` command with `--status`, `--title` options
- `term ship` command (mark done + cleanup worker)
- Local backend support in `term close`
- Beads feature gating

## Test plan

- [x] `term update wish-1 --status done` updates tasks.json
- [x] `term ship wish-15` marks done and cleans worker
- [x] `term close wish-16` works for local wishes (no bd errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)