### PR TITLE
feat(install): add --local flag for development installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "0.260203.0637",
+  "version": "0.260203.1008",
   "description": "Collaborative terminal toolkit for human + AI workflows",
   "type": "module",
   "bin": {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,5 +1,5 @@
 // Runtime version (baked in at build time)
-export const VERSION = '0.260203.0637';
+export const VERSION = '0.260203.1008';
 
 // Generate version string from current datetime
 // Format: 0.YYMMDD.HHMM (e.g., 0.260201.1430 = Feb 1, 2026 at 14:30)


### PR DESCRIPTION
- Install from local source directory instead of npm
- Build and link globally via bun/npm link  
- Symlink Claude Code plugin to local version
- Usage: ./install.sh --local /path/to/genie-cli

Enables fast local development iteration where source changes are immediately available to both CLI and Claude Code sessions.