### PR TITLE
fix: pass plugin directory to openclaw plugins install instead of .ts file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -607,12 +607,12 @@ install_openclaw_plugin() {
 
     if $DEV_MODE; then
         log "Linking OpenClaw plugin (dev mode)..."
-        openclaw plugins install -l "$plugin_file" \
+        openclaw plugins install -l "$plugin_dir" \
             && success "OpenClaw plugin linked" \
             || warn "OpenClaw plugin link failed"
     else
         log "Installing OpenClaw plugin (copy mode)..."
-        openclaw plugins install "$plugin_file" \
+        openclaw plugins install "$plugin_dir" \
             && success "OpenClaw plugin installed" \
             || warn "OpenClaw plugin install failed"
     fi
@@ -671,21 +671,20 @@ install_genie_cli() {
 
             # Also register as OpenClaw plugin if available
             if check_command openclaw; then
-                local openclaw_plugin_file="$plugin_dir/automagik-genie.ts"
-                if [[ -f "$openclaw_plugin_file" ]]; then
+                if [[ -f "$plugin_dir/openclaw.plugin.json" ]]; then
                     if $DEV_MODE; then
                         log "Linking OpenClaw plugin (dev mode)..."
-                        openclaw plugins install -l "$openclaw_plugin_file" 2>/dev/null \
+                        openclaw plugins install -l "$plugin_dir" 2>/dev/null \
                             && success "OpenClaw plugin linked" \
                             || warn "OpenClaw plugin link failed (may already be installed)"
                     else
                         log "Installing OpenClaw plugin (copy mode)..."
-                        openclaw plugins install "$openclaw_plugin_file" 2>/dev/null \
+                        openclaw plugins install "$plugin_dir" 2>/dev/null \
                             && success "OpenClaw plugin installed" \
                             || warn "OpenClaw plugin install failed (may already be installed)"
                     fi
                 else
-                    warn "OpenClaw plugin entrypoint not found: $openclaw_plugin_file"
+                    warn "OpenClaw plugin manifest not found: $plugin_dir/openclaw.plugin.json"
                 fi
             fi
         else


### PR DESCRIPTION
## Problem

The `install.sh` script passes the TypeScript entrypoint file (`automagik-genie.ts`) to `openclaw plugins install`, but OpenClaw expects a **plugin directory** containing `openclaw.plugin.json`.

This causes OpenClaw to:
1. Copy only the `.ts` file to `~/.openclaw/extensions/`
2. Generate a minimal manifest **missing required fields** (`id`, `configSchema`)
3. Fail to start with: `plugin manifest requires configSchema`

## Root Cause

```bash
# Bug (lines 610, 615, 678, 683):
openclaw plugins install "$plugin_file"  # passes .ts file

# Fix:
openclaw plugins install "$plugin_dir"   # passes directory with manifest
```

## Fix

- Pass `$plugin_dir` (the directory containing `openclaw.plugin.json`) instead of `$plugin_file` (the `.ts` entrypoint)
- Update existence check to verify the manifest file rather than the entrypoint

## Testing

Verified fix resolves the issue on Debian 13 with OpenClaw 2026.2.3-1.