### PR TITLE
feat: collaborative wish editing for external agents

### DIFF
--- a/src/lib/wish-editor.test.ts
+++ b/src/lib/wish-editor.test.ts
@@ -1,0 +1,658 @@
+/**
+ * Tests for the wish-editor module — collaborative wish document editing
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  parseSections,
+  readWish,
+  editWish,
+  readChangelog,
+  hasChanges,
+  getLastModification,
+  findSection,
+  listSections,
+  wishExists,
+  listWishSlugs,
+  getWishPath,
+  getChangelogPath,
+} from './wish-editor.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const SAMPLE_WISH = `# Wish: Test Feature
+
+**Status:** DRAFT
+**Slug:** test-feature
+**Created:** 2026-02-11
+**Author:** TestBot
+
+---
+
+## Summary
+
+This is a test wish document for collaborative editing tests.
+
+## Scope
+
+### IN
+- Item 1
+- Item 2
+
+### OUT
+- Not this
+
+## Success Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Notes
+
+Some notes here.
+`;
+
+// ============================================================================
+// Setup / Teardown
+// ============================================================================
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'wish-editor-test-'));
+  const wishDir = join(tmpDir, '.genie', 'wishes', 'test-feature');
+  await mkdir(wishDir, { recursive: true });
+  await writeFile(join(wishDir, 'wish.md'), SAMPLE_WISH);
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// parseSections
+// ============================================================================
+
+describe('parseSections', () => {
+  it('should parse all sections from a wish document', () => {
+    const sections = parseSections(SAMPLE_WISH);
+    const headings = sections.map(s => s.heading);
+
+    expect(headings).toContain('Wish: Test Feature');
+    expect(headings).toContain('Summary');
+    expect(headings).toContain('Scope');
+    expect(headings).toContain('IN');
+    expect(headings).toContain('OUT');
+    expect(headings).toContain('Success Criteria');
+    expect(headings).toContain('Notes');
+  });
+
+  it('should detect heading levels correctly', () => {
+    const sections = parseSections(SAMPLE_WISH);
+
+    const h1 = sections.find(s => s.heading === 'Wish: Test Feature');
+    expect(h1?.level).toBe(1);
+
+    const h2 = sections.find(s => s.heading === 'Summary');
+    expect(h2?.level).toBe(2);
+
+    const h3 = sections.find(s => s.heading === 'IN');
+    expect(h3?.level).toBe(3);
+  });
+
+  it('should set correct line ranges', () => {
+    const sections = parseSections(SAMPLE_WISH);
+    const summary = sections.find(s => s.heading === 'Summary');
+
+    expect(summary).toBeDefined();
+    expect(summary!.startLine).toBeGreaterThan(0);
+    expect(summary!.endLine).toBeGreaterThan(summary!.startLine);
+    expect(summary!.content).toContain('This is a test wish document');
+  });
+
+  it('should handle empty content', () => {
+    const sections = parseSections('');
+    expect(sections).toEqual([]);
+  });
+
+  it('should handle content with no headings', () => {
+    const sections = parseSections('Just some text\nwith no headings');
+    expect(sections).toEqual([]);
+  });
+});
+
+// ============================================================================
+// readWish
+// ============================================================================
+
+describe('readWish', () => {
+  it('should read and parse a wish document', async () => {
+    const doc = await readWish(tmpDir, 'test-feature');
+
+    expect(doc).not.toBeNull();
+    expect(doc!.slug).toBe('test-feature');
+    expect(doc!.raw).toContain('# Wish: Test Feature');
+    expect(doc!.sections.length).toBeGreaterThan(0);
+    expect(doc!.mtime).toBeGreaterThan(0);
+  });
+
+  it('should return null for non-existent wish', async () => {
+    const doc = await readWish(tmpDir, 'does-not-exist');
+    expect(doc).toBeNull();
+  });
+});
+
+// ============================================================================
+// findSection
+// ============================================================================
+
+describe('findSection', () => {
+  it('should find section by exact match', async () => {
+    const doc = await readWish(tmpDir, 'test-feature');
+    const section = findSection(doc!, 'Summary');
+
+    expect(section).not.toBeNull();
+    expect(section!.heading).toBe('Summary');
+  });
+
+  it('should find section by partial match', async () => {
+    const doc = await readWish(tmpDir, 'test-feature');
+    const section = findSection(doc!, 'success');
+
+    expect(section).not.toBeNull();
+    expect(section!.heading).toBe('Success Criteria');
+  });
+
+  it('should be case-insensitive', async () => {
+    const doc = await readWish(tmpDir, 'test-feature');
+    const section = findSection(doc!, 'SUMMARY');
+
+    expect(section).not.toBeNull();
+    expect(section!.heading).toBe('Summary');
+  });
+
+  it('should return null for non-existent section', async () => {
+    const doc = await readWish(tmpDir, 'test-feature');
+    const section = findSection(doc!, 'Nonexistent Section');
+
+    expect(section).toBeNull();
+  });
+});
+
+// ============================================================================
+// listSections
+// ============================================================================
+
+describe('listSections', () => {
+  it('should list all sections with metadata', async () => {
+    const doc = await readWish(tmpDir, 'test-feature');
+    const sections = listSections(doc!);
+
+    expect(sections.length).toBeGreaterThan(0);
+    expect(sections[0]).toHaveProperty('heading');
+    expect(sections[0]).toHaveProperty('level');
+    expect(sections[0]).toHaveProperty('lineCount');
+  });
+});
+
+// ============================================================================
+// editWish - replace_section
+// ============================================================================
+
+describe('editWish - replace_section', () => {
+  it('should replace a section content', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'replace_section',
+        section: 'Notes',
+        content: '## Notes\n\nUpdated notes from external agent.',
+      },
+      'OpenClaw',
+      'Updated notes section'
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.changelogEntry).toBeDefined();
+    expect(result.changelogEntry!.author).toBe('OpenClaw');
+
+    // Verify the file was updated
+    const updated = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    expect(updated).toContain('Updated notes from external agent.');
+    expect(updated).not.toContain('Some notes here.');
+  });
+
+  it('should fail for non-existent section', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'replace_section',
+        section: 'Nonexistent',
+        content: 'new content',
+      },
+      'TestAgent',
+      'test'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  it('should fail for non-existent wish', async () => {
+    const result = await editWish(
+      tmpDir,
+      'no-such-wish',
+      {
+        type: 'replace_section',
+        section: 'Summary',
+        content: 'new content',
+      },
+      'TestAgent',
+      'test'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+
+  it('should require section parameter', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'replace_section',
+        content: 'new content',
+      },
+      'TestAgent',
+      'test'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('required');
+  });
+});
+
+// ============================================================================
+// editWish - update_field
+// ============================================================================
+
+describe('editWish - update_field', () => {
+  it('should update the Status field', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'update_field',
+        field: 'Status',
+        content: 'APPROVED',
+      },
+      'OpenClaw',
+      'Approved the wish'
+    );
+
+    expect(result.success).toBe(true);
+
+    const updated = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    expect(updated).toContain('**Status:** APPROVED');
+    expect(updated).not.toContain('**Status:** DRAFT');
+  });
+
+  it('should update the Author field', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'update_field',
+        field: 'Author',
+        content: 'OpenClaw Orchestrator',
+      },
+      'OpenClaw',
+      'Changed author'
+    );
+
+    expect(result.success).toBe(true);
+
+    const updated = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    expect(updated).toContain('**Author:** OpenClaw Orchestrator');
+  });
+
+  it('should fail for non-existent field', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'update_field',
+        field: 'Priority',
+        content: 'P0',
+      },
+      'TestAgent',
+      'test'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+});
+
+// ============================================================================
+// editWish - append_section
+// ============================================================================
+
+describe('editWish - append_section', () => {
+  it('should append content to end of document', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'append_section',
+        content: '## Review Results\n\n**Verdict:** SHIP\nAll criteria pass.',
+        section: 'Review Results',
+      },
+      'ReviewBot',
+      'Added review results'
+    );
+
+    expect(result.success).toBe(true);
+
+    const updated = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    expect(updated).toContain('## Review Results');
+    expect(updated).toContain('**Verdict:** SHIP');
+  });
+});
+
+// ============================================================================
+// editWish - insert_after
+// ============================================================================
+
+describe('editWish - insert_after', () => {
+  it('should insert content after a specific section', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'insert_after',
+        afterSection: 'Summary',
+        content: '## Decisions\n\n| # | Decision | Rationale |\n|---|----------|-----------|',
+      },
+      'PlannerBot',
+      'Added decisions section'
+    );
+
+    expect(result.success).toBe(true);
+
+    const updated = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    const summaryIdx = updated.indexOf('## Summary');
+    const decisionsIdx = updated.indexOf('## Decisions');
+    const scopeIdx = updated.indexOf('## Scope');
+
+    expect(decisionsIdx).toBeGreaterThan(summaryIdx);
+    expect(decisionsIdx).toBeLessThan(scopeIdx);
+  });
+
+  it('should fail for non-existent afterSection', async () => {
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'insert_after',
+        afterSection: 'Nonexistent',
+        content: 'new content',
+      },
+      'TestAgent',
+      'test'
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+});
+
+// ============================================================================
+// editWish - replace_content
+// ============================================================================
+
+describe('editWish - replace_content', () => {
+  it('should replace entire document content', async () => {
+    const newContent = '# Wish: Completely New\n\n**Status:** APPROVED\n\nNew content.\n';
+    const result = await editWish(
+      tmpDir,
+      'test-feature',
+      {
+        type: 'replace_content',
+        content: newContent,
+      },
+      'Rewriter',
+      'Complete rewrite'
+    );
+
+    expect(result.success).toBe(true);
+
+    const updated = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    expect(updated).toBe(newContent);
+  });
+});
+
+// ============================================================================
+// Changelog
+// ============================================================================
+
+describe('changelog', () => {
+  it('should create changelog entries on edit', async () => {
+    await editWish(
+      tmpDir,
+      'test-feature',
+      { type: 'update_field', field: 'Status', content: 'APPROVED' },
+      'Agent1',
+      'First edit'
+    );
+
+    await editWish(
+      tmpDir,
+      'test-feature',
+      { type: 'update_field', field: 'Status', content: 'IN_PROGRESS' },
+      'Agent2',
+      'Second edit'
+    );
+
+    const entries = await readChangelog(tmpDir, 'test-feature');
+    expect(entries.length).toBe(2);
+    expect(entries[0].author).toBe('Agent1');
+    expect(entries[0].summary).toBe('First edit');
+    expect(entries[1].author).toBe('Agent2');
+    expect(entries[1].summary).toBe('Second edit');
+  });
+
+  it('should return empty array for wish with no changelog', async () => {
+    const entries = await readChangelog(tmpDir, 'test-feature');
+    expect(entries).toEqual([]);
+  });
+
+  it('should detect changes since timestamp', async () => {
+    const beforeEdit = Date.now();
+
+    // Small delay to ensure timestamp difference
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    await editWish(
+      tmpDir,
+      'test-feature',
+      { type: 'update_field', field: 'Status', content: 'APPROVED' },
+      'Agent1',
+      'Status change'
+    );
+
+    const result = await hasChanges(tmpDir, 'test-feature', beforeEdit);
+    expect(result.changed).toBe(true);
+    expect(result.entries.length).toBe(1);
+  });
+
+  it('should report no changes when nothing changed', async () => {
+    const result = await hasChanges(tmpDir, 'test-feature', Date.now());
+    expect(result.changed).toBe(false);
+    expect(result.entries.length).toBe(0);
+  });
+});
+
+// ============================================================================
+// getLastModification
+// ============================================================================
+
+describe('getLastModification', () => {
+  it('should return last changelog entry', async () => {
+    await editWish(
+      tmpDir,
+      'test-feature',
+      { type: 'update_field', field: 'Status', content: 'APPROVED' },
+      'Agent1',
+      'First'
+    );
+    await editWish(
+      tmpDir,
+      'test-feature',
+      { type: 'update_field', field: 'Status', content: 'DONE' },
+      'Agent2',
+      'Second'
+    );
+
+    const last = await getLastModification(tmpDir, 'test-feature');
+    expect(last).not.toBeNull();
+    expect(last!.author).toBe('Agent2');
+    expect(last!.summary).toBe('Second');
+  });
+
+  it('should return null when no changelog exists', async () => {
+    const last = await getLastModification(tmpDir, 'test-feature');
+    expect(last).toBeNull();
+  });
+});
+
+// ============================================================================
+// wishExists / listWishSlugs
+// ============================================================================
+
+describe('wishExists', () => {
+  it('should return true for existing wish', async () => {
+    expect(await wishExists(tmpDir, 'test-feature')).toBe(true);
+  });
+
+  it('should return false for non-existent wish', async () => {
+    expect(await wishExists(tmpDir, 'nope')).toBe(false);
+  });
+});
+
+describe('listWishSlugs', () => {
+  it('should list all wish slugs', async () => {
+    // Create a second wish
+    const dir2 = join(tmpDir, '.genie', 'wishes', 'second-wish');
+    await mkdir(dir2, { recursive: true });
+    await writeFile(join(dir2, 'wish.md'), '# Wish: Second\n');
+
+    const slugs = await listWishSlugs(tmpDir);
+    expect(slugs).toContain('test-feature');
+    expect(slugs).toContain('second-wish');
+  });
+
+  it('should skip directories without wish.md', async () => {
+    const dir2 = join(tmpDir, '.genie', 'wishes', 'empty-dir');
+    await mkdir(dir2, { recursive: true });
+
+    const slugs = await listWishSlugs(tmpDir);
+    expect(slugs).toContain('test-feature');
+    expect(slugs).not.toContain('empty-dir');
+  });
+
+  it('should return empty array when no wishes directory', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'empty-'));
+    const slugs = await listWishSlugs(emptyDir);
+    expect(slugs).toEqual([]);
+    await rm(emptyDir, { recursive: true, force: true });
+  });
+});
+
+// ============================================================================
+// Multi-agent editing scenario
+// ============================================================================
+
+describe('multi-agent collaborative editing', () => {
+  it('should handle sequential edits from multiple agents', async () => {
+    // Agent 1 (worker) updates status
+    const r1 = await editWish(
+      tmpDir, 'test-feature',
+      { type: 'update_field', field: 'Status', content: 'IN_PROGRESS' },
+      'claude-worker-1', 'Worker started implementation'
+    );
+    expect(r1.success).toBe(true);
+
+    // Agent 2 (orchestrator) adds review section
+    const r2 = await editWish(
+      tmpDir, 'test-feature',
+      {
+        type: 'append_section',
+        content: '## Orchestrator Notes\n\nPriority bumped. Ship by EOD.',
+        section: 'Orchestrator Notes',
+      },
+      'OpenClaw', 'Added priority note'
+    );
+    expect(r2.success).toBe(true);
+
+    // Agent 3 (reviewer) replaces success criteria
+    const r3 = await editWish(
+      tmpDir, 'test-feature',
+      {
+        type: 'replace_section',
+        section: 'Success Criteria',
+        content: '## Success Criteria\n\n- [x] Criterion 1\n- [x] Criterion 2\n- [ ] Criterion 3 (in progress)',
+      },
+      'review-agent', 'Updated criteria progress'
+    );
+    expect(r3.success).toBe(true);
+
+    // Verify final state
+    const final = await readFile(getWishPath(tmpDir, 'test-feature'), 'utf-8');
+    expect(final).toContain('**Status:** IN_PROGRESS');
+    expect(final).toContain('Orchestrator Notes');
+    expect(final).toContain('Priority bumped');
+    expect(final).toContain('[x] Criterion 1');
+
+    // Verify changelog has all 3 entries
+    const changelog = await readChangelog(tmpDir, 'test-feature');
+    expect(changelog.length).toBe(3);
+    expect(changelog.map(e => e.author)).toEqual([
+      'claude-worker-1',
+      'OpenClaw',
+      'review-agent',
+    ]);
+  });
+
+  it('should preserve content hashes for conflict detection', async () => {
+    await editWish(
+      tmpDir, 'test-feature',
+      { type: 'update_field', field: 'Status', content: 'APPROVED' },
+      'Agent1', 'First edit'
+    );
+
+    await editWish(
+      tmpDir, 'test-feature',
+      { type: 'update_field', field: 'Status', content: 'IN_PROGRESS' },
+      'Agent2', 'Second edit'
+    );
+
+    const changelog = await readChangelog(tmpDir, 'test-feature');
+
+    // Each entry should have hashes
+    expect(changelog[0].previousHash).toBeDefined();
+    expect(changelog[0].newHash).toBeDefined();
+
+    // The new hash of edit 1 should match the previous hash of edit 2
+    // (since edit 2 reads the document after edit 1 wrote it)
+    expect(changelog[1].previousHash).toBe(changelog[0].newHash);
+  });
+});

--- a/src/lib/wish-editor.ts
+++ b/src/lib/wish-editor.ts
@@ -1,0 +1,501 @@
+/**
+ * Wish Editor - Collaborative wish document editing
+ *
+ * Enables external agents (OpenClaw, orchestrators, other Claude sessions)
+ * to safely read and edit wish documents written by Claude Code workers.
+ *
+ * Protocol:
+ *   1. Read wish document → get current content
+ *   2. Propose edit → specify section + new content
+ *   3. Edit recorded in changelog → .genie/wishes/<slug>/changelog.jsonl
+ *   4. Workers detect changes via changelog mtime or polling
+ *
+ * Design principles:
+ *   - File-based (works across processes, no HTTP needed)
+ *   - Section-level edits (not line-level, avoids merge conflicts)
+ *   - Changelog for audit trail and conflict detection
+ *   - Lock-free (optimistic concurrency via version tracking)
+ */
+
+import { readFile, writeFile, mkdir, access, appendFile, stat } from 'fs/promises';
+import { join } from 'path';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Represents a parsed wish document with sections
+ */
+export interface WishDocument {
+  /** Raw markdown content */
+  raw: string;
+  /** Wish slug */
+  slug: string;
+  /** Parsed sections (keyed by heading text) */
+  sections: WishSection[];
+  /** File modification time (for optimistic concurrency) */
+  mtime: number;
+  /** File path */
+  path: string;
+}
+
+/**
+ * A section in a wish document (delimited by ## headings)
+ */
+export interface WishSection {
+  /** Section heading (without ##) */
+  heading: string;
+  /** Section content (including the heading line) */
+  content: string;
+  /** Line offset in the document */
+  startLine: number;
+  /** End line (exclusive) */
+  endLine: number;
+  /** Nesting level (1 = #, 2 = ##, 3 = ###) */
+  level: number;
+}
+
+/**
+ * An edit operation on a wish document
+ */
+export interface WishEdit {
+  /** Type of edit */
+  type: 'replace_section' | 'append_section' | 'insert_after' | 'replace_content' | 'update_field';
+  /** Target section heading (for section-level edits) */
+  section?: string;
+  /** New content to write */
+  content: string;
+  /** For insert_after: insert after this section */
+  afterSection?: string;
+  /** For update_field: field name in frontmatter-style lines (e.g., "Status") */
+  field?: string;
+}
+
+/**
+ * A changelog entry recording who edited what
+ */
+export interface ChangelogEntry {
+  /** ISO timestamp */
+  timestamp: string;
+  /** Who made the edit (agent name, session ID, etc.) */
+  author: string;
+  /** What kind of edit */
+  editType: WishEdit['type'];
+  /** Which section was affected */
+  section?: string;
+  /** Brief description of the change */
+  summary: string;
+  /** Previous content hash (for conflict detection) */
+  previousHash?: string;
+  /** New content hash */
+  newHash?: string;
+}
+
+/**
+ * Result of an edit operation
+ */
+export interface EditResult {
+  /** Whether the edit was successful */
+  success: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** The updated document */
+  document?: WishDocument;
+  /** The changelog entry that was created */
+  changelogEntry?: ChangelogEntry;
+}
+
+// ============================================================================
+// Path Utilities
+// ============================================================================
+
+/**
+ * Get the wish document path
+ */
+export function getWishPath(repoPath: string, slug: string): string {
+  return join(repoPath, '.genie', 'wishes', slug, 'wish.md');
+}
+
+/**
+ * Get the changelog path for a wish
+ */
+export function getChangelogPath(repoPath: string, slug: string): string {
+  return join(repoPath, '.genie', 'wishes', slug, 'changelog.jsonl');
+}
+
+/**
+ * Get the wish directory
+ */
+export function getWishDir(repoPath: string, slug: string): string {
+  return join(repoPath, '.genie', 'wishes', slug);
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+/**
+ * Parse a wish document into sections
+ */
+export function parseSections(content: string): WishSection[] {
+  const lines = content.split('\n');
+  const sections: WishSection[] = [];
+  let currentSection: Partial<WishSection> | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const headingMatch = line.match(/^(#{1,4})\s+(.+)$/);
+
+    if (headingMatch) {
+      // Close previous section
+      if (currentSection) {
+        currentSection.endLine = i;
+        currentSection.content = lines.slice(currentSection.startLine!, i).join('\n');
+        sections.push(currentSection as WishSection);
+      }
+
+      // Start new section
+      currentSection = {
+        heading: headingMatch[2].trim(),
+        level: headingMatch[1].length,
+        startLine: i,
+      };
+    }
+  }
+
+  // Close last section
+  if (currentSection) {
+    currentSection.endLine = lines.length;
+    currentSection.content = lines.slice(currentSection.startLine!).join('\n');
+    sections.push(currentSection as WishSection);
+  }
+
+  return sections;
+}
+
+/**
+ * Read and parse a wish document
+ */
+export async function readWish(repoPath: string, slug: string): Promise<WishDocument | null> {
+  const wishPath = getWishPath(repoPath, slug);
+
+  try {
+    const [content, fileStat] = await Promise.all([
+      readFile(wishPath, 'utf-8'),
+      stat(wishPath),
+    ]);
+
+    return {
+      raw: content,
+      slug,
+      sections: parseSections(content),
+      mtime: fileStat.mtimeMs,
+      path: wishPath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find a section by heading (case-insensitive, partial match)
+ */
+export function findSection(document: WishDocument, heading: string): WishSection | null {
+  const lower = heading.toLowerCase();
+
+  // Exact match first
+  const exact = document.sections.find(s => s.heading.toLowerCase() === lower);
+  if (exact) return exact;
+
+  // Partial match (heading contains search term)
+  const partial = document.sections.find(s => s.heading.toLowerCase().includes(lower));
+  return partial || null;
+}
+
+/**
+ * List all section headings in a wish document
+ */
+export function listSections(document: WishDocument): Array<{ heading: string; level: number; lineCount: number }> {
+  return document.sections.map(s => ({
+    heading: s.heading,
+    level: s.level,
+    lineCount: s.endLine - s.startLine,
+  }));
+}
+
+// ============================================================================
+// Simple content hash for conflict detection
+// ============================================================================
+
+function simpleHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash).toString(36);
+}
+
+// ============================================================================
+// Edit Operations
+// ============================================================================
+
+/**
+ * Apply an edit to a wish document
+ *
+ * @param repoPath - Repository root path
+ * @param slug - Wish slug
+ * @param edit - The edit to apply
+ * @param author - Who is making the edit
+ * @param summary - Brief description of the change
+ * @returns Edit result
+ */
+export async function editWish(
+  repoPath: string,
+  slug: string,
+  edit: WishEdit,
+  author: string,
+  summary: string
+): Promise<EditResult> {
+  // Read current document
+  const doc = await readWish(repoPath, slug);
+  if (!doc) {
+    return { success: false, error: `Wish "${slug}" not found` };
+  }
+
+  const lines = doc.raw.split('\n');
+  let newContent: string;
+  let sectionName = edit.section;
+
+  try {
+    switch (edit.type) {
+      case 'replace_section': {
+        if (!edit.section) {
+          return { success: false, error: 'section is required for replace_section' };
+        }
+        const section = findSection(doc, edit.section);
+        if (!section) {
+          return { success: false, error: `Section "${edit.section}" not found. Available: ${doc.sections.map(s => s.heading).join(', ')}` };
+        }
+        sectionName = section.heading;
+
+        // Replace the section content
+        const before = lines.slice(0, section.startLine);
+        const after = lines.slice(section.endLine);
+        newContent = [...before, edit.content, ...after].join('\n');
+        break;
+      }
+
+      case 'append_section': {
+        // Append a new section at the end of the document
+        newContent = doc.raw.trimEnd() + '\n\n' + edit.content + '\n';
+        sectionName = edit.section || '(appended)';
+        break;
+      }
+
+      case 'insert_after': {
+        if (!edit.afterSection) {
+          return { success: false, error: 'afterSection is required for insert_after' };
+        }
+        const afterSec = findSection(doc, edit.afterSection);
+        if (!afterSec) {
+          return { success: false, error: `Section "${edit.afterSection}" not found` };
+        }
+
+        const beforeInsert = lines.slice(0, afterSec.endLine);
+        const afterInsert = lines.slice(afterSec.endLine);
+        newContent = [...beforeInsert, '', edit.content, ...afterInsert].join('\n');
+        sectionName = edit.section || `(after ${afterSec.heading})`;
+        break;
+      }
+
+      case 'replace_content': {
+        // Replace the entire document content
+        newContent = edit.content;
+        sectionName = '(entire document)';
+        break;
+      }
+
+      case 'update_field': {
+        if (!edit.field) {
+          return { success: false, error: 'field is required for update_field' };
+        }
+
+        // Find and update a frontmatter-style field like **Status:** DRAFT
+        const fieldPattern = new RegExp(
+          `^(\\*\\*${escapeRegExp(edit.field)}:\\*\\*\\s*)(.+)$`,
+          'im'
+        );
+        const match = doc.raw.match(fieldPattern);
+
+        if (match) {
+          newContent = doc.raw.replace(fieldPattern, `$1${edit.content}`);
+        } else {
+          return {
+            success: false,
+            error: `Field "${edit.field}" not found in document. ` +
+              `Expected format: **${edit.field}:** value`,
+          };
+        }
+        sectionName = `field:${edit.field}`;
+        break;
+      }
+
+      default:
+        return { success: false, error: `Unknown edit type: ${edit.type}` };
+    }
+
+    // Write updated content
+    const wishPath = getWishPath(repoPath, slug);
+    await writeFile(wishPath, newContent);
+
+    // Create changelog entry
+    const changelogEntry: ChangelogEntry = {
+      timestamp: new Date().toISOString(),
+      author,
+      editType: edit.type,
+      section: sectionName,
+      summary,
+      previousHash: simpleHash(doc.raw),
+      newHash: simpleHash(newContent),
+    };
+
+    await appendChangelog(repoPath, slug, changelogEntry);
+
+    // Re-read the updated document
+    const updatedDoc = await readWish(repoPath, slug);
+
+    return {
+      success: true,
+      document: updatedDoc || undefined,
+      changelogEntry,
+    };
+  } catch (error: any) {
+    return { success: false, error: `Edit failed: ${error.message}` };
+  }
+}
+
+// ============================================================================
+// Changelog
+// ============================================================================
+
+/**
+ * Append an entry to the wish changelog
+ */
+async function appendChangelog(
+  repoPath: string,
+  slug: string,
+  entry: ChangelogEntry
+): Promise<void> {
+  const changelogPath = getChangelogPath(repoPath, slug);
+  const dir = getWishDir(repoPath, slug);
+
+  // Ensure directory exists
+  await mkdir(dir, { recursive: true });
+
+  // Append as JSONL
+  const line = JSON.stringify(entry) + '\n';
+  await appendFile(changelogPath, line);
+}
+
+/**
+ * Read the changelog for a wish
+ */
+export async function readChangelog(
+  repoPath: string,
+  slug: string
+): Promise<ChangelogEntry[]> {
+  const changelogPath = getChangelogPath(repoPath, slug);
+
+  try {
+    const content = await readFile(changelogPath, 'utf-8');
+    return content
+      .trim()
+      .split('\n')
+      .filter(line => line.trim())
+      .map(line => JSON.parse(line) as ChangelogEntry);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check if a wish has been modified since a given timestamp
+ */
+export async function hasChanges(
+  repoPath: string,
+  slug: string,
+  sinceMs: number
+): Promise<{ changed: boolean; entries: ChangelogEntry[] }> {
+  const entries = await readChangelog(repoPath, slug);
+  const recentEntries = entries.filter(e => new Date(e.timestamp).getTime() > sinceMs);
+
+  return {
+    changed: recentEntries.length > 0,
+    entries: recentEntries,
+  };
+}
+
+/**
+ * Get the last modification info for a wish
+ */
+export async function getLastModification(
+  repoPath: string,
+  slug: string
+): Promise<ChangelogEntry | null> {
+  const entries = await readChangelog(repoPath, slug);
+  return entries.length > 0 ? entries[entries.length - 1] : null;
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+/**
+ * Escape special regex characters
+ */
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Check if a wish exists
+ */
+export async function wishExists(repoPath: string, slug: string): Promise<boolean> {
+  try {
+    await access(getWishPath(repoPath, slug));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List all wish slugs in a repository
+ */
+export async function listWishSlugs(repoPath: string): Promise<string[]> {
+  const wishesDir = join(repoPath, '.genie', 'wishes');
+
+  try {
+    const { readdir } = await import('fs/promises');
+    const entries = await readdir(wishesDir, { withFileTypes: true });
+    const slugs: string[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        try {
+          await access(join(wishesDir, entry.name, 'wish.md'));
+          slugs.push(entry.name);
+        } catch {
+          // No wish.md in this directory
+        }
+      }
+    }
+
+    return slugs.sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/term-commands/wish/commands.ts
+++ b/src/term-commands/wish/commands.ts
@@ -1,17 +1,37 @@
 /**
- * Wish Namespace - Wish document management
+ * Wish Namespace - Wish document management & collaborative editing
  *
  * Groups all wish-related commands under `term wish`.
  *
  * Commands:
- *   term wish ls               - List all wishes
- *   term wish status <slug>    - Show wish with linked tasks status
+ *   term wish ls                    - List all wishes
+ *   term wish status <slug>         - Show wish with linked tasks status
+ *   term wish show <slug>           - Alias for status
+ *   term wish read <slug>           - Read wish document (or specific section)
+ *   term wish edit <slug>           - Edit a wish document section
+ *   term wish set-status <slug> <s> - Update wish status field
+ *   term wish append <slug>         - Append a new section
+ *   term wish changelog <slug>      - View edit history
+ *   term wish sections <slug>       - List all sections in a wish
+ *   term wish diff <slug>           - Check for changes since timestamp
  */
 
 import { Command } from 'commander';
 import { readdir, readFile, access } from 'fs/promises';
 import { join } from 'path';
 import { getWishTasks, getWishStatus, LinkedTask } from '../../lib/wish-tasks.js';
+import {
+  readWish,
+  editWish,
+  readChangelog,
+  hasChanges,
+  findSection,
+  listSections,
+  wishExists,
+  getWishPath,
+  type WishEdit,
+  type ChangelogEntry,
+} from '../../lib/wish-editor.js';
 
 // ============================================================================
 // Types
@@ -64,6 +84,14 @@ async function parseWishFrontmatter(wishPath: string): Promise<{ title: string; 
         if (line.startsWith('status:')) {
           status = line.substring(7).trim().toUpperCase();
         }
+      }
+    }
+
+    // Fallback: look for **Status:** pattern (wish.md style)
+    if (status === 'DRAFT') {
+      const statusMatch = content.match(/\*\*Status:\*\*\s*(.+)/i);
+      if (statusMatch) {
+        status = statusMatch[1].trim().toUpperCase();
       }
     }
 
@@ -122,11 +150,11 @@ async function listWishes(repoPath: string): Promise<WishSummary[]> {
  */
 function formatTaskStatus(status: LinkedTask['status']): string {
   switch (status) {
-    case 'done': return '✅';
-    case 'in_progress': return '🔄';
-    case 'blocked': return '🔴';
-    case 'open': return '⚪';
-    default: return '❓';
+    case 'done': return '\u2705';
+    case 'in_progress': return '\uD83D\uDD04';
+    case 'blocked': return '\uD83D\uDD34';
+    case 'open': return '\u26AA';
+    default: return '\u2753';
   }
 }
 
@@ -135,13 +163,33 @@ function formatTaskStatus(status: LinkedTask['status']): string {
  */
 function formatWishStatus(status: string): string {
   switch (status.toUpperCase()) {
-    case 'READY': return '🟢 READY';
-    case 'IN_PROGRESS': return '🔄 IN_PROGRESS';
-    case 'BLOCKED': return '🔴 BLOCKED';
-    case 'DONE': return '✅ DONE';
-    case 'DRAFT': return '📝 DRAFT';
+    case 'READY': return '\uD83D\uDFE2 READY';
+    case 'APPROVED': return '\uD83D\uDFE2 APPROVED';
+    case 'IN_PROGRESS': return '\uD83D\uDD04 IN_PROGRESS';
+    case 'BLOCKED': return '\uD83D\uDD34 BLOCKED';
+    case 'DONE': return '\u2705 DONE';
+    case 'DRAFT': return '\uD83D\uDCDD DRAFT';
     default: return status;
   }
+}
+
+/**
+ * Format a changelog entry for display
+ */
+function formatChangelogEntry(entry: ChangelogEntry): string {
+  const time = new Date(entry.timestamp).toLocaleString();
+  const section = entry.section ? ` [${entry.section}]` : '';
+  return `  ${time}  ${entry.author}  ${entry.editType}${section}\n    ${entry.summary}`;
+}
+
+/**
+ * Get default author name from environment
+ */
+function getAuthorName(): string {
+  return process.env.GENIE_AUTHOR
+    || process.env.CLAUDE_SESSION_ID
+    || process.env.USER
+    || 'unknown';
 }
 
 // ============================================================================
@@ -154,7 +202,37 @@ function formatWishStatus(status: string): string {
 export function registerWishNamespace(program: Command): void {
   const wishProgram = program
     .command('wish')
-    .description('Wish document management');
+    .description(`Wish document management and collaborative editing
+
+BROWSE
+  wish ls                         List all wishes
+  wish status <slug>              Wish status with linked tasks
+  wish show <slug>                Alias for status
+
+READ / INSPECT
+  wish read <slug>                Read wish document (or section with --section)
+  wish sections <slug>            List all sections in a wish
+
+COLLABORATIVE EDITING
+  wish edit <slug>                Replace a section in a wish
+  wish set-status <slug> <status> Update wish status (DRAFT/APPROVED/IN_PROGRESS/DONE)
+  wish append <slug>              Append a new section to a wish
+  wish set-field <slug> <field>   Update any **Field:** value in the document
+
+HISTORY
+  wish changelog <slug>           View edit history
+  wish diff <slug>                Check for changes since a timestamp
+
+Examples:
+  term wish read forge-resilience --section "Success Criteria"
+  term wish set-status forge-resilience APPROVED --author "OpenClaw"
+  term wish edit forge-resilience --section "Review Results" --content "..."
+  term wish append forge-resilience --heading "## Notes" --content "Added by orchestrator"
+  term wish changelog forge-resilience --since 1h`);
+
+  // ============================================================================
+  // BROWSE commands
+  // ============================================================================
 
   // wish ls - List all wishes
   wishProgram
@@ -176,11 +254,11 @@ export function registerWishNamespace(program: Command): void {
         return;
       }
 
-      console.log('┌────────────────────────────────────────────────────────────────────┐');
-      console.log('│ WISHES                                                             │');
-      console.log('├──────────────────────┬───────────────┬──────────────────────────────┤');
-      console.log('│ Slug                 │ Status        │ Tasks (done/total)           │');
-      console.log('├──────────────────────┼───────────────┼──────────────────────────────┤');
+      console.log('\u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510');
+      console.log('\u2502 WISHES                                                             \u2502');
+      console.log('\u251C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524');
+      console.log('\u2502 Slug                 \u2502 Status        \u2502 Tasks (done/total)           \u2502');
+      console.log('\u251C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524');
 
       for (const wish of wishes) {
         const slug = wish.slug.padEnd(20).substring(0, 20);
@@ -189,10 +267,10 @@ export function registerWishNamespace(program: Command): void {
           ? `${wish.tasks.done}/${wish.tasks.total} (${wish.tasks.inProgress} active, ${wish.tasks.blocked} blocked)`
           : '(no tasks)';
         const tasks = taskProgress.padEnd(28).substring(0, 28);
-        console.log(`│ ${slug} │ ${status} │ ${tasks} │`);
+        console.log(`\u2502 ${slug} \u2502 ${status} \u2502 ${tasks} \u2502`);
       }
 
-      console.log('└──────────────────────┴───────────────┴──────────────────────────────┘');
+      console.log('\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518');
     });
 
   // wish status <slug> - Show wish with linked tasks
@@ -208,7 +286,7 @@ export function registerWishNamespace(program: Command): void {
       try {
         await access(wishPath);
       } catch {
-        console.error(`❌ Wish "${slug}" not found in .genie/wishes/`);
+        console.error(`\u274C Wish "${slug}" not found in .genie/wishes/`);
         process.exit(1);
       }
 
@@ -228,7 +306,7 @@ export function registerWishNamespace(program: Command): void {
       }
 
       // Display wish info
-      console.log(`\n📋 ${title}`);
+      console.log(`\n\uD83D\uDCCB ${title}`);
       console.log(`   Slug: ${slug}`);
       console.log(`   Status: ${formatWishStatus(status)}`);
       console.log('');
@@ -243,18 +321,18 @@ export function registerWishNamespace(program: Command): void {
         if (taskStatus.open > 0) console.log(`          ${taskStatus.open} open`);
         console.log('');
 
-        console.log('   ┌────────────┬──────────────────────────────────────┬──────────┐');
-        console.log('   │ Task ID    │ Title                                │ Status   │');
-        console.log('   ├────────────┼──────────────────────────────────────┼──────────┤');
+        console.log('   \u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510');
+        console.log('   \u2502 Task ID    \u2502 Title                                \u2502 Status   \u2502');
+        console.log('   \u251C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524');
 
         for (const task of tasks) {
           const taskId = task.id.padEnd(10).substring(0, 10);
           const taskTitle = task.title.padEnd(36).substring(0, 36);
           const taskState = `${formatTaskStatus(task.status)} ${task.status}`.padEnd(8).substring(0, 8);
-          console.log(`   │ ${taskId} │ ${taskTitle} │ ${taskState} │`);
+          console.log(`   \u2502 ${taskId} \u2502 ${taskTitle} \u2502 ${taskState} \u2502`);
         }
 
-        console.log('   └────────────┴──────────────────────────────────────┴──────────┘');
+        console.log('   \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518');
       }
 
       console.log('');
@@ -272,4 +350,416 @@ export function registerWishNamespace(program: Command): void {
         await statusCmd.parseAsync([slug, ...(options.json ? ['--json'] : [])], { from: 'user' });
       }
     });
+
+  // ============================================================================
+  // READ / INSPECT commands
+  // ============================================================================
+
+  // wish read <slug> - Read wish document (entire or specific section)
+  wishProgram
+    .command('read <slug>')
+    .description('Read wish document content (full or specific section)')
+    .option('-s, --section <name>', 'Read only a specific section (partial match)')
+    .option('--json', 'Output as JSON')
+    .action(async (slug: string, options: { section?: string; json?: boolean }) => {
+      const repoPath = process.cwd();
+      const doc = await readWish(repoPath, slug);
+
+      if (!doc) {
+        console.error(`\u274C Wish "${slug}" not found in .genie/wishes/`);
+        process.exit(1);
+      }
+
+      if (options.section) {
+        const section = findSection(doc, options.section);
+        if (!section) {
+          console.error(`\u274C Section "${options.section}" not found in wish "${slug}".`);
+          console.error(`Available sections: ${doc.sections.map(s => s.heading).join(', ')}`);
+          process.exit(1);
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify({
+            slug,
+            section: section.heading,
+            level: section.level,
+            content: section.content,
+            lineRange: { start: section.startLine, end: section.endLine },
+          }, null, 2));
+        } else {
+          console.log(section.content);
+        }
+      } else {
+        if (options.json) {
+          console.log(JSON.stringify({
+            slug,
+            path: doc.path,
+            sections: doc.sections.map(s => s.heading),
+            content: doc.raw,
+          }, null, 2));
+        } else {
+          console.log(doc.raw);
+        }
+      }
+    });
+
+  // wish sections <slug> - List all sections
+  wishProgram
+    .command('sections <slug>')
+    .description('List all sections in a wish document')
+    .option('--json', 'Output as JSON')
+    .action(async (slug: string, options: { json?: boolean }) => {
+      const repoPath = process.cwd();
+      const doc = await readWish(repoPath, slug);
+
+      if (!doc) {
+        console.error(`\u274C Wish "${slug}" not found`);
+        process.exit(1);
+      }
+
+      const sections = listSections(doc);
+
+      if (options.json) {
+        console.log(JSON.stringify(sections, null, 2));
+        return;
+      }
+
+      console.log(`\nSections in wish "${slug}":\n`);
+      for (const section of sections) {
+        const indent = '  '.repeat(section.level - 1);
+        const prefix = '#'.repeat(section.level);
+        console.log(`${indent}${prefix} ${section.heading}  (${section.lineCount} lines)`);
+      }
+      console.log('');
+    });
+
+  // ============================================================================
+  // COLLABORATIVE EDITING commands
+  // ============================================================================
+
+  // wish edit <slug> - Replace a section
+  wishProgram
+    .command('edit <slug>')
+    .description('Replace a section in a wish document')
+    .requiredOption('-s, --section <name>', 'Section heading to replace (partial match)')
+    .requiredOption('-c, --content <text>', 'New content for the section (use @file to read from file)')
+    .option('-a, --author <name>', 'Author of the edit (default: env GENIE_AUTHOR or USER)')
+    .option('-m, --message <text>', 'Edit summary message')
+    .option('--json', 'Output result as JSON')
+    .action(async (slug: string, options: {
+      section: string;
+      content: string;
+      author?: string;
+      message?: string;
+      json?: boolean;
+    }) => {
+      const repoPath = process.cwd();
+      const author = options.author || getAuthorName();
+
+      // Support @file syntax for content
+      let content = options.content;
+      if (content.startsWith('@') && content.length > 1) {
+        const filePath = content.substring(1);
+        try {
+          content = await readFile(filePath, 'utf-8');
+        } catch (error: any) {
+          console.error(`\u274C Cannot read content from file "${filePath}": ${error.message}`);
+          process.exit(1);
+        }
+      }
+
+      const edit: WishEdit = {
+        type: 'replace_section',
+        section: options.section,
+        content,
+      };
+
+      const summary = options.message || `Replace section "${options.section}"`;
+      const result = await editWish(repoPath, slug, edit, author, summary);
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.success) {
+        console.log(`\u2705 Section "${options.section}" updated in wish "${slug}"`);
+        console.log(`   Author: ${author}`);
+        if (result.changelogEntry) {
+          console.log(`   Logged: ${result.changelogEntry.timestamp}`);
+        }
+      } else {
+        console.error(`\u274C Edit failed: ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // wish set-status <slug> <status> - Update wish status
+  wishProgram
+    .command('set-status <slug> <status>')
+    .description('Update the **Status:** field in a wish document')
+    .option('-a, --author <name>', 'Author of the change')
+    .option('-m, --message <text>', 'Change summary')
+    .option('--json', 'Output result as JSON')
+    .action(async (slug: string, status: string, options: {
+      author?: string;
+      message?: string;
+      json?: boolean;
+    }) => {
+      const repoPath = process.cwd();
+      const author = options.author || getAuthorName();
+
+      const edit: WishEdit = {
+        type: 'update_field',
+        field: 'Status',
+        content: status.toUpperCase(),
+      };
+
+      const summary = options.message || `Status changed to ${status.toUpperCase()}`;
+      const result = await editWish(repoPath, slug, edit, author, summary);
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.success) {
+        console.log(`\u2705 Status updated: ${formatWishStatus(status.toUpperCase())}`);
+        console.log(`   Wish: ${slug}`);
+        console.log(`   Author: ${author}`);
+      } else {
+        console.error(`\u274C Failed: ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // wish append <slug> - Append a new section
+  wishProgram
+    .command('append <slug>')
+    .description('Append a new section to a wish document')
+    .requiredOption('-c, --content <text>', 'Content to append (use @file to read from file)')
+    .option('-h, --heading <text>', 'Section heading (e.g., "## Review Results")')
+    .option('-a, --author <name>', 'Author of the change')
+    .option('-m, --message <text>', 'Change summary')
+    .option('--after <section>', 'Insert after this section (instead of at end)')
+    .option('--json', 'Output result as JSON')
+    .action(async (slug: string, options: {
+      content: string;
+      heading?: string;
+      author?: string;
+      message?: string;
+      after?: string;
+      json?: boolean;
+    }) => {
+      const repoPath = process.cwd();
+      const author = options.author || getAuthorName();
+
+      // Support @file syntax
+      let content = options.content;
+      if (content.startsWith('@') && content.length > 1) {
+        const filePath = content.substring(1);
+        try {
+          content = await readFile(filePath, 'utf-8');
+        } catch (error: any) {
+          console.error(`\u274C Cannot read content from file "${filePath}": ${error.message}`);
+          process.exit(1);
+        }
+      }
+
+      // Prepend heading if provided
+      if (options.heading) {
+        content = `${options.heading}\n\n${content}`;
+      }
+
+      let edit: WishEdit;
+      if (options.after) {
+        edit = {
+          type: 'insert_after',
+          afterSection: options.after,
+          content,
+          section: options.heading?.replace(/^#+\s*/, ''),
+        };
+      } else {
+        edit = {
+          type: 'append_section',
+          section: options.heading?.replace(/^#+\s*/, ''),
+          content,
+        };
+      }
+
+      const summary = options.message || `Append section${options.heading ? `: ${options.heading}` : ''}`;
+      const result = await editWish(repoPath, slug, edit, author, summary);
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.success) {
+        console.log(`\u2705 Content appended to wish "${slug}"`);
+        console.log(`   Author: ${author}`);
+        if (result.changelogEntry) {
+          console.log(`   Logged: ${result.changelogEntry.timestamp}`);
+        }
+      } else {
+        console.error(`\u274C Append failed: ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // wish set-field <slug> <field> - Update any **Field:** value
+  wishProgram
+    .command('set-field <slug> <field>')
+    .description('Update any **Field:** value in a wish document (e.g., Author, Priority)')
+    .requiredOption('-v, --value <text>', 'New value for the field')
+    .option('-a, --author <name>', 'Author of the change')
+    .option('-m, --message <text>', 'Change summary')
+    .option('--json', 'Output result as JSON')
+    .action(async (slug: string, field: string, options: {
+      value: string;
+      author?: string;
+      message?: string;
+      json?: boolean;
+    }) => {
+      const repoPath = process.cwd();
+      const author = options.author || getAuthorName();
+
+      const edit: WishEdit = {
+        type: 'update_field',
+        field,
+        content: options.value,
+      };
+
+      const summary = options.message || `Updated ${field} to "${options.value}"`;
+      const result = await editWish(repoPath, slug, edit, author, summary);
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.success) {
+        console.log(`\u2705 Field "${field}" updated to "${options.value}"`);
+        console.log(`   Wish: ${slug}`);
+        console.log(`   Author: ${author}`);
+      } else {
+        console.error(`\u274C Failed: ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // ============================================================================
+  // HISTORY commands
+  // ============================================================================
+
+  // wish changelog <slug> - View edit history
+  wishProgram
+    .command('changelog <slug>')
+    .description('View edit history (changelog) for a wish')
+    .option('--since <duration>', 'Show entries since duration (e.g., 1h, 30m, 2d)')
+    .option('-n, --last <count>', 'Show last N entries', parseInt)
+    .option('--json', 'Output as JSON')
+    .action(async (slug: string, options: { since?: string; last?: number; json?: boolean }) => {
+      const repoPath = process.cwd();
+
+      if (!await wishExists(repoPath, slug)) {
+        console.error(`\u274C Wish "${slug}" not found`);
+        process.exit(1);
+      }
+
+      let entries = await readChangelog(repoPath, slug);
+
+      // Filter by --since
+      if (options.since) {
+        const sinceMs = parseDuration(options.since);
+        if (sinceMs) {
+          const cutoff = Date.now() - sinceMs;
+          entries = entries.filter(e => new Date(e.timestamp).getTime() > cutoff);
+        }
+      }
+
+      // Limit by --last
+      if (options.last && options.last > 0) {
+        entries = entries.slice(-options.last);
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify(entries, null, 2));
+        return;
+      }
+
+      if (entries.length === 0) {
+        console.log(`No changelog entries for wish "${slug}".`);
+        console.log('Changelog tracks edits made via "term wish edit/set-status/append".');
+        return;
+      }
+
+      console.log(`\nChangelog for wish "${slug}" (${entries.length} entries):\n`);
+      for (const entry of entries) {
+        console.log(formatChangelogEntry(entry));
+        console.log('');
+      }
+    });
+
+  // wish diff <slug> - Check for changes since timestamp
+  wishProgram
+    .command('diff <slug>')
+    .description('Check if wish has been modified since a timestamp')
+    .option('--since <duration>', 'Check for changes since duration (e.g., 1h, 30m)')
+    .option('--since-ms <timestamp>', 'Check since epoch milliseconds', parseInt)
+    .option('--json', 'Output as JSON')
+    .action(async (slug: string, options: { since?: string; sinceMs?: number; json?: boolean }) => {
+      const repoPath = process.cwd();
+
+      if (!await wishExists(repoPath, slug)) {
+        console.error(`\u274C Wish "${slug}" not found`);
+        process.exit(1);
+      }
+
+      let sinceMs: number;
+      if (options.sinceMs) {
+        sinceMs = options.sinceMs;
+      } else if (options.since) {
+        const duration = parseDuration(options.since);
+        sinceMs = duration ? Date.now() - duration : Date.now() - 3600000; // default 1h
+      } else {
+        sinceMs = Date.now() - 3600000; // default: 1 hour ago
+      }
+
+      const result = await hasChanges(repoPath, slug, sinceMs);
+
+      if (options.json) {
+        console.log(JSON.stringify({
+          slug,
+          changed: result.changed,
+          sinceMs,
+          sinceIso: new Date(sinceMs).toISOString(),
+          entryCount: result.entries.length,
+          entries: result.entries,
+        }, null, 2));
+        return;
+      }
+
+      if (result.changed) {
+        console.log(`\uD83D\uDD04 Wish "${slug}" has ${result.entries.length} change(s) since ${new Date(sinceMs).toLocaleString()}:`);
+        for (const entry of result.entries) {
+          console.log(formatChangelogEntry(entry));
+          console.log('');
+        }
+      } else {
+        console.log(`\u2705 No changes to wish "${slug}" since ${new Date(sinceMs).toLocaleString()}.`);
+      }
+    });
+}
+
+// ============================================================================
+// Duration Parsing
+// ============================================================================
+
+/**
+ * Parse a duration string like "1h", "30m", "2d" into milliseconds
+ */
+function parseDuration(duration: string): number | null {
+  const match = duration.match(/^(\d+)\s*(ms|s|m|h|d)$/i);
+  if (!match) return null;
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+
+  switch (unit) {
+    case 'ms': return value;
+    case 's': return value * 1000;
+    case 'm': return value * 60 * 1000;
+    case 'h': return value * 60 * 60 * 1000;
+    case 'd': return value * 24 * 60 * 60 * 1000;
+    default: return null;
+  }
 }

--- a/src/term.ts
+++ b/src/term.ts
@@ -64,9 +64,14 @@ TASKS (beads integration)
   task ls             List ready tasks
   task link           Link task to wish
 
-WISHES (planning)
+WISHES (planning + collaborative editing)
   wish ls             List all wishes
   wish status <slug>  Show wish with linked tasks
+  wish read <slug>    Read wish content (or section)
+  wish edit <slug>    Edit a wish section
+  wish set-status     Update wish status field
+  wish append         Append section to wish
+  wish changelog      View wish edit history
 
 SESSIONS (low-level tmux) - see: term session --help
   session new/ls/attach/rm/exec/send/read/info/split


### PR DESCRIPTION
## Summary

- Add `wish-editor` library enabling external agents (OpenClaw, orchestrators) to read and edit wish documents authored by Claude Code workers
- Add 8 new `term wish` subcommands: `read`, `edit`, `set-status`, `append`, `set-field`, `sections`, `changelog`, `diff`
- All edits tracked in JSONL changelog (`.genie/wishes/<slug>/changelog.jsonl`) with author, timestamp, and content hashes for audit trail and conflict detection
- File-based protocol — works across processes with no HTTP/IPC needed

## Test plan

- [x] 36 new tests covering all edit operations, changelog, multi-agent scenarios — all passing
- [x] Full test suite: 542 pass (pre-existing 1 fail unchanged)
- [ ] Manual: `term wish read forge-resilience --section "Success Criteria"`
- [ ] Manual: `term wish set-status forge-resilience DONE --author "OpenClaw"`
- [ ] Manual: `term wish changelog forge-resilience`

🤖 Generated with [Claude Code](https://claude.com/claude-code)