### PR TITLE
fix(genie-pdf): normalize frontmatter fields and prevent borderRadius crash

### DIFF
--- a/packages/genie-pdf/src/components/Markdown.tsx
+++ b/packages/genie-pdf/src/components/Markdown.tsx
@@ -102,7 +102,7 @@ export function Markdown({ tokens, theme }: MarkdownProps) {
       backgroundColor: isGlass 
         ? "rgba(99, 102, 241, 0.06)" 
         : "transparent",
-      borderRadius: isGlass ? 4 : 0,
+      ...(isGlass && { borderRadius: 4 }),
     },
     blockquoteText: {
       fontSize: 10,

--- a/packages/genie-pdf/src/render.ts
+++ b/packages/genie-pdf/src/render.ts
@@ -12,6 +12,14 @@ export interface RenderOptions {
   showPageNumbers?: boolean;
 }
 
+function toOptionalString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+
+  const text = String(value).trim();
+  return text.length > 0 ? text : undefined;
+}
+
 export async function renderMarkdownToPDF(options: RenderOptions): Promise<void> {
   const { input, output, theme: themeName = "default", showPageNumbers = true } = options;
 
@@ -50,10 +58,10 @@ export async function renderMarkdownToPDF(options: RenderOptions): Promise<void>
   const doc = React.createElement(
     Document,
     {
-      title: parsed.frontmatter.title as string | undefined,
-      subtitle: parsed.frontmatter.subtitle as string | undefined,
-      author: parsed.frontmatter.author as string | undefined,
-      date: parsed.frontmatter.date as string | undefined,
+      title: toOptionalString(parsed.frontmatter.title),
+      subtitle: toOptionalString(parsed.frontmatter.subtitle),
+      author: toOptionalString(parsed.frontmatter.author),
+      date: toOptionalString(parsed.frontmatter.date),
       theme,
       showPageNumbers,
       children,

--- a/packages/genie-pdf/src/render.ts
+++ b/packages/genie-pdf/src/render.ts
@@ -13,8 +13,13 @@ export interface RenderOptions {
 }
 
 function toOptionalString(value: unknown): string | undefined {
-  if (value === null || value === undefined) return undefined;
-  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (value == null) return undefined;
+  if (value instanceof Date) {
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, "0");
+    const day = String(value.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
 
   const text = String(value).trim();
   return text.length > 0 ? text : undefined;


### PR DESCRIPTION
## Summary
- normalize markdown frontmatter values before passing metadata into `Document`
- prevent react-pdf stylesheet crash from falsy `borderRadius` in markdown blockquote styles
- preserve behavior while eliminating empty-string warnings and runtime render failure

## Changes
- `packages/genie-pdf/src/render.ts`
  - add `toOptionalString()` helper:
    - `null`/`undefined` -> `undefined`
    - `Date` -> `YYYY-MM-DD`
    - empty/whitespace strings -> `undefined`
    - all other values -> trimmed string
  - use helper for `title`, `subtitle`, `author`, `date` props
- `packages/genie-pdf/src/components/Markdown.tsx`
  - replace `borderRadius: isGlass ? 4 : 0` with conditional spread
  - avoids passing a falsy radius value through react-pdf stylesheet shorthand resolution path

## Validation
- repro command now succeeds:
  - `cd packages/genie-pdf && bun run src/index.ts render templates/example.md -o /tmp/genie-pdf-test-fixed.pdf`
- template render sanity:
  - `cd packages/genie-pdf && bun run src/index.ts template invoice --data templates/example-invoice.json -o /tmp/genie-pdf-invoice-test.pdf`
- package build:
  - `cd packages/genie-pdf && bun run build`

## Notes
- `bun run typecheck` in `packages/genie-pdf` still fails due to pre-existing unrelated type errors in `Flowchart.tsx`, `themes/*`, and one markdown token narrowing warning. Those are not introduced by this PR.
