### PR TITLE
feat(skills): add depends-on/blocks dependency fields

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -34,3 +34,5 @@ Use for early-stage or ambiguous ideas.
 ## Handoff Message
 
 `Design validated. Run /wish to turn this into an executable plan.`
+
+Note any cross-repo or cross-agent dependencies discovered during brainstorm — these become `depends-on`/`blocks` fields in the wish.

--- a/skills/wish/SKILL.md
+++ b/skills/wish/SKILL.md
@@ -23,6 +23,7 @@ If no prior brainstorm/design context exists, ask first:
 ## Required Wish Sections
 - Status, slug, date
 - Problem/summary
+- Dependencies: `depends-on` / `blocks` (optional — use `slug` or `repo/slug` for cross-repo)
 - Scope IN / OUT
 - Key decisions + rationale
 - Success criteria (checkboxes)
@@ -33,3 +34,4 @@ If no prior brainstorm/design context exists, ask first:
 - No vague tasks ("do everything").
 - Every task must be testable.
 - Keep tasks bite-sized and shippable.
+- Tag dependencies early — if a wish depends on another, declare it.


### PR DESCRIPTION
## Wish: wish-dependencies

Adds `depends-on` and `blocks` optional fields to the wish template so agents can declare cross-wish and cross-repo dependencies.

### Changes
- **wish/SKILL.md**: Added `depends-on`/`blocks` to Required Wish Sections + dependency rule
- **brainstorm/SKILL.md**: Added dependency awareness note in handoff message

### Usage
```
**Depends-on:** auth-refactor
**Blocks:** genie-cli/dashboard-v2
```

Cross-repo format: `repo/slug`. Scannable via `grep -r depends-on .genie/wishes/`.

4 lines added, 0 removed. Ship it.