### PR TITLE
feat(skills): framework v2 — subagent architecture + /fix skill

### DIFF
--- a/.genie/wishes/wrs-backlog-reorg/wish.md
+++ b/.genie/wishes/wrs-backlog-reorg/wish.md
@@ -1,0 +1,268 @@
+# Wish: WRS Backlog Reorganization and Sofia Co-Triage
+
+**Status:** APPROVED
+**Slug:** wrs-backlog-reorg
+**Created:** 2026-02-13
+**Author:** Genie 🧞
+**Brainstorm:** `.genie/brainstorms/wrs-backlog-reorg/design.md`
+
+---
+
+## Summary
+
+Reorganize current work into a single WRS-aligned prioritization model, then publish a shared backlog with Sofia using explicit scoring, triage buckets, and execution gates for large epics.
+
+## Dependencies
+
+- **depends-on:** `forge-resilience` (reference baseline for acceptance rigor and resilience framing)
+- **blocks:** `hooks-v2`, `workflow-rebrand`, `omnichannel-agent-platform` (until priority policy + triage order are explicit)
+
+## Scope
+
+### IN
+- Define and document one weighted scoring framework for backlog prioritization
+- Define triage method (`Now / Next / Later`) and gating rules
+- Inventory the current planning set discussed with Felipe/Sofia
+- Assign first-pass ranking with short rationale per item
+- Mark shipped/residual items clearly (avoid re-planning already-shipped work)
+- Create recurring co-ownership cadence (Genie + Sofia) for backlog refresh
+
+### OUT
+- Implementing any feature/bug item in the backlog itself
+- Redesigning WRS internals or changing skill behavior
+- Multi-quarter roadmap expansion beyond current planning set
+- Cross-repo delivery execution details (this wish is prioritization/governance only)
+
+## Key Decisions + Rationale
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Use weighted score: Blocking 30, Stability 25, Cross-impact 20, Quick-win 15, Complexity-inverse 10 | Keeps foundation and reliability ahead of cosmetic/isolated work |
+| D2 | Triage by policy: P0+blockers first, then foundation/integration, then feature slices, epics decomposed before execution | Prevents queue churn and premature epic execution |
+| D3 | Keep first-pass list explicit with `Now/Next/Later` | Produces immediate operator clarity and handoff quality |
+| D4 | Treat `upgrade-brainstorm` and `forge-resilience` as status-validation items unless regressions exist | Avoids duplicate work and backlog inflation |
+| D5 | Require short rationale tags (`impacto/bloqueio/quick win/estabilidade`) on top-ranked items | Makes prioritization auditable and PM-friendly |
+
+---
+
+## WRS Backlog Scoring (Canonical Policy)
+
+Priority score formula:
+
+```text
+PriorityScore =
+  (Blocking * 0.30) +
+  (Stability * 0.25) +
+  (Cross-impact * 0.20) +
+  (Quick-win * 0.15) +
+  (Complexity-inverse * 0.10)
+```
+
+Scale each dimension 0–5.
+
+- **Blocking (30%)**: how much it unblocks downstream work
+- **Stability (25%)**: effect on reliability/incident reduction
+- **Cross-impact (20%)**: breadth across agents/repos/flows
+- **Quick-win (15%)**: value delivery speed (1–3 day slices favored)
+- **Complexity-inverse (10%)**: lower execution risk scores higher
+
+### Reusable Template Snippet
+
+```text
+Item:
+Type: bug|integration|feature|epic|status-check
+Scores (0-5): Blocking=?, Stability=?, Cross-impact=?, Quick-win=?, Complexity-inverse=?
+Weighted Score: ?/5
+Bucket: Now|Next|Later
+Rationale tags: impacto|bloqueio|quick win|estabilidade
+```
+
+## Triage Rules (Deterministic)
+
+1. **P0 bugs/incidents and hard blockers first**.
+2. **Foundation/integration before surface features**.
+3. **Medium work must be sliced into 1–3 day shippable chunks**.
+4. **Epics are decompose-first** (discovery + task breakdown before queueing execution).
+5. **Status-check items are not treated as net-new build** (close/monitor/defer lane).
+
+---
+
+## Inventory Normalization (Current Planning Set)
+
+| Item | Type | Risk | Note |
+|---|---|---|---|
+| provider-system-refactor | integration/foundation | high | Core provider architecture; unblocker for downstream consistency |
+| whatsapp-openclaw-integration-test | integration/test | medium | Validates end-to-end reliability before feature expansion |
+| Omni bug #7 | bug | medium | Production bug; stability-first handling |
+| Omni bug #8 | bug | medium | Production bug; grouped with bug batch |
+| Omni bug #9 | bug | medium | Production bug; likely fast stabilization win |
+| telegram-channel-activation | feature/ops | low | Communication redundancy and quick operational value |
+| medium-features | feature-batch | medium | Incremental capabilities once base is stable |
+| media-drive-download | feature/enablement | medium | Media ingestion/download support for workflows |
+| workflow-rebrand | feature/product | medium | Product-facing polish/positioning; non-blocking |
+| hooks-v2 | epic | high | High-impact but broad scope; needs decomposition |
+| omnichannel-agent-platform | epic | high | Umbrella platform initiative; decompose before build |
+| forge-resilience | status-check | low | Already shipped baseline; monitor/hardening lane |
+| upgrade-brainstorm | status-check | low | Validate shipped/residual work; avoid duplicate effort |
+
+---
+
+## First-Pass Priority Output
+
+### Now
+1. provider-system-refactor — **bloqueio + estabilidade + impacto transversal**
+2. whatsapp-openclaw-integration-test — **estabilidade + bloqueio**
+3. Omni bug #7 — **estabilidade**
+4. Omni bug #8 — **estabilidade**
+5. Omni bug #9 — **estabilidade / quick win**
+6. telegram-channel-activation — **quick win + redundância operacional**
+
+### Next
+7. medium-features — **impacto incremental**
+8. media-drive-download — **enablement operacional**
+9. workflow-rebrand — **impacto de produto, baixo bloqueio técnico**
+
+### Later (decompose-first)
+10. hooks-v2 — **alto impacto, alto escopo**
+11. omnichannel-agent-platform — **épico guarda-chuva, precisa fatiamento**
+
+### Status-check lane (not net-new build priority)
+- forge-resilience — monitor/hardening if regressions
+- upgrade-brainstorm — validate shipped state; close residuals only
+
+---
+
+## Governance and Cadence with Sofia
+
+- **Owners:**
+  - Genie: technical sequencing and dependency sanity
+  - Sofia: PM governance, priority enforcement, delivery framing
+- **Cadence:** 2x weekly lightweight backlog refresh (Tue/Fri)
+- **Per-cycle artifact:** update this wish (or successor backlog wish) with:
+  1) ranked table,
+  2) `Now/Next/Later` bucket deltas,
+  3) short **delta log** (what moved and why)
+- **Decision split:**
+  - Genie can propose reorderings based on technical blockers
+  - Sofia finalizes queue for execution handoff
+
+---
+
+## Success Criteria
+
+- [ ] Scoring framework is documented and reusable for future backlog refreshes
+- [ ] Triage method is documented with unambiguous ordering rules
+- [ ] Current item inventory is captured with source labels
+- [ ] First-pass prioritized list exists with concise rationale per item
+- [ ] `Now/Next/Later` buckets are published and consistent with scoring
+- [ ] Epics are flagged with decomposition gate (not directly queued for implementation)
+- [ ] Shipped/residual items are labeled (close/monitor/defer) to reduce noise
+- [ ] Sofia + Genie review cadence is defined (owner, frequency, output artifact)
+
+---
+
+## Execution Groups
+
+### Group A — Scoring Policy and Triage Rules
+**Goal:** Create the canonical prioritization policy.
+
+**Deliverables:**
+- `WRS Backlog Scoring` section with weighted criteria
+- `Triage Rules` section with deterministic ordering
+- Template snippet for future backlog scoring reuse
+
+**Acceptance Criteria:**
+- [ ] Weights sum to 100 and are justified
+- [ ] Policy explicitly handles blockers, bugs, foundation, features, epics
+- [ ] Rules are understandable in <2 minutes by PM/operator
+
+**Validation Command:**
+```bash
+rg -n "Blocking|Stability|Cross-impact|Quick-win|Complexity" .genie/wishes/wrs-backlog-reorg/wish.md
+```
+
+---
+
+### Group B — Current Inventory Normalization
+**Goal:** Normalize and classify all currently discussed items.
+
+**Deliverables:**
+- Item table with type (`bug|integration|feature|epic|status-check`)
+- Ownership/context notes (where relevant)
+- Initial risk flags (`high/medium/low`)
+
+**Acceptance Criteria:**
+- [ ] All items listed by Felipe/Sofia are represented once
+- [ ] No ambiguous duplicate entries
+- [ ] Each item has at least type + one-line note
+
+**Validation Command:**
+```bash
+rg -n "provider-system-refactor|hooks-v2|workflow-rebrand|omnichannel-agent-platform|Omni bug #7|Omni bug #8|Omni bug #9" .genie/wishes/wrs-backlog-reorg/wish.md
+```
+
+---
+
+### Group C — First-Pass Prioritization Output
+**Goal:** Publish execution-facing queue order.
+
+**Deliverables:**
+- Ranked list with short rationale tags
+- `Now / Next / Later` buckets
+- Explicit handling of status-check items
+
+**Acceptance Criteria:**
+- [ ] Top list starts with foundation + stability items
+- [ ] Omni bug cluster is placed before broad feature expansion
+- [ ] Epics are marked “decompose-first”
+- [ ] Status-check items are not treated as net-new build work
+
+**Validation Command:**
+```bash
+rg -n "Now|Next|Later|decompose-first|status-check" .genie/wishes/wrs-backlog-reorg/wish.md
+```
+
+---
+
+### Group D — Governance and Cadence with Sofia
+**Goal:** Keep backlog ordering current and enforceable.
+
+**Deliverables:**
+- Owner model: Genie (technical sequencing) + Sofia (PM governance)
+- Cadence: lightweight review rhythm
+- Output artifact location for each review pass
+
+**Acceptance Criteria:**
+- [ ] Cadence frequency is explicit
+- [ ] Each cycle has a concrete output (updated ranked table + delta log)
+- [ ] Decision ownership split is clear
+
+**Validation Command:**
+```bash
+rg -n "cadence|owner|Sofia|Genie|delta" .genie/wishes/wrs-backlog-reorg/wish.md
+```
+
+---
+
+## Planned Validation
+
+```bash
+# Group A
+rg -n "Blocking|Stability|Cross-impact|Quick-win|Complexity" .genie/wishes/wrs-backlog-reorg/wish.md
+
+# Group B
+rg -n "provider-system-refactor|hooks-v2|workflow-rebrand|omnichannel-agent-platform|Omni bug #7|Omni bug #8|Omni bug #9" .genie/wishes/wrs-backlog-reorg/wish.md
+
+# Group C
+rg -n "Now|Next|Later|decompose-first|status-check" .genie/wishes/wrs-backlog-reorg/wish.md
+
+# Group D
+rg -n "cadence|owner|Sofia|Genie|delta" .genie/wishes/wrs-backlog-reorg/wish.md
+```
+
+---
+
+## Task Tracking Notes
+
+- Use this wish as the source for creating/updating `bd` items and dependency edges in the next step.
+- For cross-repo work, keep dependency notation in `repo/slug` form.

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -15,9 +15,10 @@ Handle a FIX-FIRST verdict from `/review`. Dispatch fixes via subagent, then re-
 3. **Re-review:** dispatch `/review` subagent to validate the fix.
 4. **Check verdict:**
    - **SHIP** → done, return to orchestrator.
-   - **FIX-FIRST** → increment loop counter, go to step 2 (if loop ≤ 2).
+   - **FIX-FIRST** + loop < 2 → increment loop counter, go to step 2.
+   - **FIX-FIRST** + loop = 2 → escalate (max reached).
    - **BLOCKED** → escalate immediately.
-5. **Loop exceeded (> 2):** mark task BLOCKED, report to orchestrator with remaining gaps.
+5. **Escalation (loop = 2 or BLOCKED):** mark task BLOCKED, report to orchestrator with remaining gaps.
 
 ## Subagent Dispatch
 
@@ -30,11 +31,11 @@ sessions_send(
   timeoutSeconds: 120
 )
 
-# Re-review subagent
+# Re-review subagent (use same pipeline as original review)
 sessions_send(
   agentId: "<self>",
   sessionKey: "agent:<self>:reviewer-<slug>-loop<N>",
-  message: "Review fix for wish <slug>. Pipeline: execution. Check: <gap list resolved?>",
+  message: "Review fix for wish <slug>. Pipeline: <original_pipeline>. Check: <gap list resolved?>",
   timeoutSeconds: 120
 )
 ```

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: fix
+description: "Handle FIX-FIRST verdicts from /review — dispatch fix subagent, re-review, escalate after 2 loops."
+---
+
+# /fix
+
+Handle a FIX-FIRST verdict from `/review`. Dispatch fixes via subagent, then re-review.
+
+**Max 2 loops. After that → BLOCKED → escalate to human.**
+
+## Flow
+1. **Load gaps:** parse the FIX-FIRST verdict — extract gap list with severity and files.
+2. **Dispatch fixer:** send gaps + original wish context to a fix subagent.
+3. **Re-review:** dispatch `/review` subagent to validate the fix.
+4. **Check verdict:**
+   - **SHIP** → done, return to orchestrator.
+   - **FIX-FIRST** → increment loop counter, go to step 2 (if loop ≤ 2).
+   - **BLOCKED** → escalate immediately.
+5. **Loop exceeded (> 2):** mark task BLOCKED, report to orchestrator with remaining gaps.
+
+## Subagent Dispatch
+
+```
+# Fix subagent
+sessions_send(
+  agentId: "<self>",
+  sessionKey: "agent:<self>:fixer-<slug>-loop<N>",
+  message: "Fix these gaps from /review of wish <slug>:\n<gap list>\nOriginal criteria: <criteria>",
+  timeoutSeconds: 120
+)
+
+# Re-review subagent
+sessions_send(
+  agentId: "<self>",
+  sessionKey: "agent:<self>:reviewer-<slug>-loop<N>",
+  message: "Review fix for wish <slug>. Pipeline: execution. Check: <gap list resolved?>",
+  timeoutSeconds: 120
+)
+```
+
+## Escalation
+
+When loop limit (2) is exceeded:
+- Mark task **BLOCKED** in wish.
+- Report remaining gaps with exact files and failing checks.
+- Message: `"Fix loop exceeded (2/2). Escalating to human. Remaining gaps: ..."`
+
+## Rules
+- Never fix and review in the same session — always separate subagents.
+- Never exceed 2 fix loops — escalate, don't spin.
+- Include original wish criteria in every fix dispatch for context.
+- Each loop must show progress — if same gaps persist, escalate immediately.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -13,8 +13,8 @@ Universal review gate. Always run as a subagent — never review your own work i
 3. Run listed validation commands and capture pass/fail output.
 4. Classify gaps: CRITICAL / HIGH / MEDIUM / LOW.
 5. Return verdict:
-   - **SHIP:** no CRITICAL/HIGH gaps, validations pass.
-   - **FIX-FIRST:** fixable gaps or failing validations → hand off to `/fix`.
+   - **SHIP:** no CRITICAL/HIGH gaps, validations pass. MEDIUM/LOW gaps are noted but don't block.
+   - **FIX-FIRST:** CRITICAL or HIGH gaps, or failing validations → hand off to `/fix`.
    - **BLOCKED:** scope/architecture issue requiring wish revision.
 6. Write actionable next steps (exact fixes, files, commands).
 
@@ -38,6 +38,7 @@ Run after `/work`. Checks implementation against wish criteria.
 - [ ] Validation commands run and passing
 - [ ] No scope creep — only wish-scoped changes made
 - [ ] Work is auditable — commands and outcomes captured
+- [ ] Quality pass: security, maintainability, correctness
 - [ ] No regressions introduced
 
 ### PR Review (pre-merge)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -5,27 +5,65 @@ description: "Universal reviewer for plans and execution - validates readiness a
 
 # /review
 
-Universal review gate for wish plans, execution output, and PR readiness.
-
-## Modes
-- **Plan review:** validate wish structure/scope before execution.
-- **Execution review:** validate completed /work results against criteria.
-- **PR review:** final ship check before merge.
+Universal review gate. Always run as a subagent — never review your own work inline.
 
 ## Flow
-1. Detect review target (wish draft, in-progress wish, or PR diff).
-2. Audit criteria one-by-one with explicit evidence.
+1. Detect review target → select pipeline (Plan, Execution, or PR).
+2. Run the pipeline checklist below.
 3. Run listed validation commands and capture pass/fail output.
-4. Perform quality pass (security, correctness, maintainability, regressions).
-5. Classify gaps: CRITICAL / HIGH / MEDIUM / LOW.
-6. Return verdict:
+4. Classify gaps: CRITICAL / HIGH / MEDIUM / LOW.
+5. Return verdict:
    - **SHIP:** no CRITICAL/HIGH gaps, validations pass.
-   - **FIX-FIRST:** fixable HIGH gaps or failing validations.
+   - **FIX-FIRST:** fixable gaps or failing validations → hand off to `/fix`.
    - **BLOCKED:** scope/architecture issue requiring wish revision.
-7. Write actionable next steps (exact fixes, files, commands).
+6. Write actionable next steps (exact fixes, files, commands).
+
+## Pipelines
+
+### Plan Review (wish draft)
+Run before `/work`. Checks the wish document quality.
+
+- [ ] Problem statement is one sentence, testable
+- [ ] Scope IN has concrete deliverables
+- [ ] Scope OUT is not empty — boundaries explicit
+- [ ] Every task has acceptance criteria that are testable
+- [ ] Tasks are bite-sized and independently shippable
+- [ ] Dependencies tagged (`depends-on` / `blocks`)
+- [ ] Validation commands exist for each execution group
+
+### Execution Review (completed /work)
+Run after `/work`. Checks implementation against wish criteria.
+
+- [ ] All acceptance criteria met with evidence
+- [ ] Validation commands run and passing
+- [ ] No scope creep — only wish-scoped changes made
+- [ ] Work is auditable — commands and outcomes captured
+- [ ] No regressions introduced
+
+### PR Review (pre-merge)
+Run before merge. Checks the diff against the wish.
+
+- [ ] Diff matches wish scope — no unrelated changes
+- [ ] File list matches wish's "Files to Create/Modify"
+- [ ] No secrets, credentials, or hardcoded tokens in diff
+- [ ] Tests pass (if applicable)
+- [ ] Commit messages reference wish slug
+
+## Subagent Rule
+
+**Always dispatch review as a subagent.** The reviewer must not be the implementor.
+
+```
+sessions_send(
+  agentId: "<self>",
+  sessionKey: "agent:<self>:reviewer-<slug>-<timestamp>",
+  message: "Review <target> against wish <slug>. Pipeline: <plan|execution|pr>.",
+  timeoutSeconds: 120
+)
+```
 
 ## Rules
 - Never mark PASS without evidence.
 - Never ship with CRITICAL/HIGH gaps.
-- Never implement fixes during /review.
+- Never implement fixes during /review — hand off to `/fix`.
 - Keep review output concise, prioritized, and executable.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -14,10 +14,11 @@ Execute an approved wish from `.genie/wishes/<slug>/wish.md`.
 2. **Pick next task:** select next unblocked pending execution group.
 3. **Dispatch subagent:** send the task to a fresh session (see Dispatch below).
 4. **Spec review:** dispatch reviewer subagent to check acceptance criteria; if fail, dispatch `/fix` (max 2 loops).
-5. **Validate:** run the group validation command and record evidence.
-6. **Mark complete:** update task state and wish checkboxes.
-7. **Repeat** until all groups are done.
-8. **Handoff:** `All work tasks complete. Run /review.`
+5. **Quality review:** dispatch reviewer subagent for quality pass (security, maintainability, perf); if fail, dispatch `/fix` (max 1 loop).
+6. **Validate:** run the group validation command and record evidence.
+7. **Mark complete:** update task state and wish checkboxes.
+8. **Repeat** until all groups are done.
+9. **Handoff:** `All work tasks complete. Run /review.`
 
 ## Dispatch
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -7,37 +7,53 @@ description: "Execute an approved wish plan - dispatches implementor subagents p
 
 Execute an approved wish from `.genie/wishes/<slug>/wish.md`.
 
+**Core principle: the orchestrator never executes directly. Always dispatch via subagent.**
+
 ## Flow
 1. **Load wish + status:** confirm scope and current progress.
 2. **Pick next task:** select next unblocked pending execution group.
-3. **Dispatch implementor:** pick a route from the Dispatch table below.
-4. **Spec review:** check acceptance criteria; if fail, fix (max 3 loops).
-5. **Quality review:** security/maintainability/perf check; if fail, fix (max 2 loops).
-6. **Validate:** run the group validation command and record evidence.
-7. **Mark complete:** update task state and wish checkboxes.
-8. **Repeat** until all groups are done.
-9. **Handoff:** `All work tasks complete. Run /review.`
+3. **Dispatch subagent:** send the task to a fresh session (see Dispatch below).
+4. **Spec review:** dispatch reviewer subagent to check acceptance criteria; if fail, dispatch `/fix` (max 2 loops).
+5. **Validate:** run the group validation command and record evidence.
+6. **Mark complete:** update task state and wish checkboxes.
+7. **Repeat** until all groups are done.
+8. **Handoff:** `All work tasks complete. Run /review.`
 
 ## Dispatch
 
-Pick the route that fits the task. When unsure, start cheap (exec) and escalate.
+The orchestrator dispatches work via `sessions_send` to fresh session keys. This creates an isolated subagent with clean context.
+
+```
+sessions_send(
+  agentId: "<self>",
+  sessionKey: "agent:<self>:worker-<group>-<timestamp>",
+  message: "Implement Group A from wish <slug>: <goal>. Acceptance criteria: ...",
+  timeoutSeconds: 120
+)
+```
+
+The subagent executes, replies with results. Orchestrator collects and moves to next group.
+
+### Route Selection
 
 | Task needs… | Route | Example | Don't use for |
 |-------------|-------|---------|---------------|
-| File edits, multi-step coding | `term work <bead>` | CC worker via claudio — state detection, auto-approve | Simple validation, reasoning-only |
-| Thinking, research, analysis | `sessions_spawn(task:"…")` | Fresh sub-agent, announces result back | File edits (no workspace access) |
-| Quick validation, grep, git | `exec("command")` | Direct shell, immediate result | Complex multi-file refactors |
-| Another agent's expertise | `sessions_send(agentId, msg)` | ClawNet cross-agent delegation | Tasks you can do locally |
+| Any implementation task | `sessions_send` to fresh key | Subagent with clean context | — |
+| Multi-file coding (heavy) | `term work <bead>` | CC worker via claudio | Simple edits, reasoning-only |
+| Quick validation only | `exec("command")` | Direct shell, immediate result | Complex multi-step work |
+| Another agent's expertise | `sessions_send(agentId, msg)` | Cross-agent delegation via ClawNet | Tasks you can do locally |
+
+**Default: `sessions_send` to fresh key.** Use `term work` for heavy coding. Use `exec` only for validation commands.
 
 ## Escalation
-If loop limit is exceeded:
+If a subagent fails or loop limit (2) is exceeded:
 - mark task BLOCKED,
 - create follow-up task with concrete gaps,
 - continue with next unblocked task,
 - include blocked items in handoff.
 
 ## Rules
+- Orchestrator never executes directly — always dispatch subagents.
 - Do not expand scope during execution.
 - Do not skip validation commands.
 - Keep work auditable: capture commands + outcomes.
-- Prefer subagents for implementation and verification.


### PR DESCRIPTION
## Framework v2: Orchestrators Never Execute

The big architecture shift: orchestrators are brains, subagents are hands.

### Changes

**`/work` — Subagent Dispatch**
- Orchestrator dispatches ALL tasks via `sessions_send` to fresh session keys
- Default route: `sessions_send` to `agent:<self>:worker-<group>-<ts>`
- `term work` kept as coding-specific alternative
- `exec` kept for validation commands only

**`/review` — 3 Pipelines with Teeth**
- **Plan Review:** 7 concrete checks (scope, criteria, dependencies, etc.)
- **Execution Review:** 5 checks (criteria met, no scope creep, auditable)
- **PR Review:** 5 checks (diff matches scope, no secrets, tests pass)
- Always runs as a separate subagent — never review your own work

**`/fix` — NEW SKILL**
- Handles FIX-FIRST verdicts from /review
- Dispatches fix + re-review as separate subagents
- 2-loop max — escalate to human after that
- Never fix and review in the same session

### The Pattern
```
sessions_send(
  agentId: "<self>",
  sessionKey: "agent:<self>:worker-groupA-1234",
  message: "Implement Group A from wish...",
  timeoutSeconds: 120
)
→ Fresh session, clean context, sync reply
```

### Why sessions_send > sessions_spawn
- Sync replies (vs async announce)
- Cross-agent via agentToAgent.allow (vs self-only allowlist)
- Cross-node via ClawNet (vs local only)
- No config changes needed