### PR TITLE
feat(term): priority queue — term feed, term next, term score

### DIFF
--- a/src/lib/local-tasks.test.ts
+++ b/src/lib/local-tasks.test.ts
@@ -12,8 +12,12 @@ import {
   claimTask,
   getTask,
   listTasks,
+  getQueue,
+  updateTask,
   isLocalTasksEnabled,
   markDone,
+  computePriorityScore,
+  type PriorityScores,
 } from './local-tasks.js';
 
 let tempDir: string;
@@ -143,5 +147,178 @@ describe('isLocalTasksEnabled', () => {
   it('should return true after ensureTasksFile creates .genie', async () => {
     await ensureTasksFile(tempDir);
     expect(isLocalTasksEnabled(tempDir)).toBe(true);
+  });
+});
+
+// ============================================================================
+// computePriorityScore
+// ============================================================================
+
+describe('computePriorityScore', () => {
+  it('should compute weighted sum correctly', () => {
+    const scores: PriorityScores = {
+      blocking: 5,
+      stability: 3,
+      crossImpact: 4,
+      quickWin: 2,
+      complexityInverse: 1,
+    };
+    // 5*0.30 + 3*0.25 + 4*0.20 + 2*0.15 + 1*0.10 = 1.50 + 0.75 + 0.80 + 0.30 + 0.10 = 3.45
+    expect(computePriorityScore(scores)).toBeCloseTo(3.45, 10);
+  });
+
+  it('should return 0 for all-zero scores', () => {
+    const scores: PriorityScores = {
+      blocking: 0,
+      stability: 0,
+      crossImpact: 0,
+      quickWin: 0,
+      complexityInverse: 0,
+    };
+    expect(computePriorityScore(scores)).toBe(0);
+  });
+
+  it('should return 5 for all-max scores', () => {
+    const scores: PriorityScores = {
+      blocking: 5,
+      stability: 5,
+      crossImpact: 5,
+      quickWin: 5,
+      complexityInverse: 5,
+    };
+    // 5*(0.30+0.25+0.20+0.15+0.10) = 5*1.00 = 5.00
+    expect(computePriorityScore(scores)).toBeCloseTo(5.0, 10);
+  });
+});
+
+// ============================================================================
+// getQueue — priority sorting
+// ============================================================================
+
+describe('getQueue priority sorting', () => {
+  it('should return tasks sorted by priority score (highest first)', async () => {
+    await ensureTasksFile(tempDir);
+
+    // Create 3 tasks — will be in creation order: wish-1, wish-2, wish-3
+    const low = await createWishTask(tempDir, 'Low priority');
+    const high = await createWishTask(tempDir, 'High priority');
+    const mid = await createWishTask(tempDir, 'Mid priority');
+
+    // Assign scores: high > mid > low
+    await updateTask(tempDir, high.id, {});
+    await updateTask(tempDir, mid.id, {});
+    await updateTask(tempDir, low.id, {});
+
+    // We need to write priorityScores directly — updateTask doesn't support it yet,
+    // so we'll manipulate the tasks file
+    const tasksPath = join(tempDir, '.genie', 'tasks.json');
+    const file = JSON.parse(await readFile(tasksPath, 'utf-8'));
+
+    file.tasks[high.id].priorityScores = {
+      blocking: 5, stability: 5, crossImpact: 5, quickWin: 5, complexityInverse: 5,
+    }; // score = 5.0
+
+    file.tasks[mid.id].priorityScores = {
+      blocking: 3, stability: 3, crossImpact: 3, quickWin: 3, complexityInverse: 3,
+    }; // score = 3.0
+
+    file.tasks[low.id].priorityScores = {
+      blocking: 1, stability: 1, crossImpact: 1, quickWin: 1, complexityInverse: 1,
+    }; // score = 1.0
+
+    await writeFile(tasksPath, JSON.stringify(file, null, 2));
+
+    const queue = await getQueue(tempDir);
+    expect(queue.ready).toEqual([high.id, mid.id, low.id]);
+  });
+
+  it('should place tasks without scores after tasks with scores', async () => {
+    await ensureTasksFile(tempDir);
+
+    const noScore = await createWishTask(tempDir, 'No score');
+    const withScore = await createWishTask(tempDir, 'With score');
+
+    // Set score on second task only
+    const tasksPath = join(tempDir, '.genie', 'tasks.json');
+    const file = JSON.parse(await readFile(tasksPath, 'utf-8'));
+
+    file.tasks[withScore.id].priorityScores = {
+      blocking: 2, stability: 2, crossImpact: 2, quickWin: 2, complexityInverse: 2,
+    }; // score = 2.0, which is > -1 (no score)
+
+    await writeFile(tasksPath, JSON.stringify(file, null, 2));
+
+    const queue = await getQueue(tempDir);
+    expect(queue.ready[0]).toBe(withScore.id);
+    expect(queue.ready[1]).toBe(noScore.id);
+  });
+
+  it('should still include blocked tasks in the blocked array', async () => {
+    await ensureTasksFile(tempDir);
+
+    const parent = await createWishTask(tempDir, 'Parent');
+    const child = await createWishTask(tempDir, 'Child', { parent: parent.id });
+
+    const queue = await getQueue(tempDir);
+    expect(queue.ready).toContain(parent.id);
+    expect(queue.blocked.length).toBe(1);
+    expect(queue.blocked[0]).toContain(child.id);
+  });
+});
+
+// ============================================================================
+// listTasks — priority sorting
+// ============================================================================
+
+describe('listTasks priority sorting', () => {
+  it('should return tasks sorted by priority score (highest first)', async () => {
+    await ensureTasksFile(tempDir);
+
+    const a = await createWishTask(tempDir, 'Task A');
+    const b = await createWishTask(tempDir, 'Task B');
+    const c = await createWishTask(tempDir, 'Task C');
+
+    // Assign scores: B(high) > C(mid) > A(low)
+    const tasksPath = join(tempDir, '.genie', 'tasks.json');
+    const file = JSON.parse(await readFile(tasksPath, 'utf-8'));
+
+    file.tasks[a.id].priorityScores = {
+      blocking: 1, stability: 1, crossImpact: 1, quickWin: 1, complexityInverse: 1,
+    }; // score = 1.0
+
+    file.tasks[b.id].priorityScores = {
+      blocking: 5, stability: 5, crossImpact: 5, quickWin: 5, complexityInverse: 5,
+    }; // score = 5.0
+
+    file.tasks[c.id].priorityScores = {
+      blocking: 3, stability: 3, crossImpact: 3, quickWin: 3, complexityInverse: 3,
+    }; // score = 3.0
+
+    await writeFile(tasksPath, JSON.stringify(file, null, 2));
+
+    const tasks = await listTasks(tempDir);
+    expect(tasks[0].id).toBe(b.id);
+    expect(tasks[1].id).toBe(c.id);
+    expect(tasks[2].id).toBe(a.id);
+  });
+
+  it('should put unscored tasks after scored tasks', async () => {
+    await ensureTasksFile(tempDir);
+
+    const unscored = await createWishTask(tempDir, 'Unscored');
+    const scored = await createWishTask(tempDir, 'Scored');
+
+    const tasksPath = join(tempDir, '.genie', 'tasks.json');
+    const file = JSON.parse(await readFile(tasksPath, 'utf-8'));
+
+    file.tasks[scored.id].priorityScores = {
+      blocking: 1, stability: 1, crossImpact: 1, quickWin: 1, complexityInverse: 1,
+    };
+
+    await writeFile(tasksPath, JSON.stringify(file, null, 2));
+
+    const tasks = await listTasks(tempDir);
+    expect(tasks[0].id).toBe(scored.id);
+    expect(tasks[1].id).toBe(unscored.id);
   });
 });

--- a/src/lib/local-tasks.ts
+++ b/src/lib/local-tasks.ts
@@ -260,6 +260,8 @@ export interface UpdateTaskOptions {
   title?: string;
   blockedBy?: string[];  // replaces existing blockedBy
   addBlockedBy?: string[];  // appends to existing blockedBy
+  priorityScores?: PriorityScores;
+  issueType?: 'task' | 'epic';
 }
 
 export async function updateTask(
@@ -286,6 +288,14 @@ export async function updateTask(
     if (options.blockedBy.length > 0 && t.status === 'ready') {
       t.status = 'blocked';
     }
+  }
+
+  if (options.priorityScores !== undefined) {
+    t.priorityScores = options.priorityScores;
+  }
+
+  if (options.issueType !== undefined) {
+    t.issueType = options.issueType;
   }
 
   if (options.addBlockedBy !== undefined && options.addBlockedBy.length > 0) {

--- a/src/term-commands/feed.ts
+++ b/src/term-commands/feed.ts
@@ -1,0 +1,126 @@
+/**
+ * Feed command - Ingest a new backlog item as a scored epic
+ *
+ * Usage:
+ *   term feed "<title>"                             - Create epic with default scores (all 3/5)
+ *   term feed "<title>" --scores '{"blocking":5}'   - Override specific dimensions
+ *   term feed "<title>" --slug <slug>               - Custom slug (default: slugified title)
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import {
+  createWishTask,
+  ensureTasksFile,
+  updateTask,
+  computePriorityScore,
+  type PriorityScores,
+} from '../lib/local-tasks.js';
+import { getRepoGenieDir } from '../lib/genie-dir.js';
+
+export interface FeedOptions {
+  scores?: string;
+  slug?: string;
+}
+
+/** Convert a title to a URL-safe slug: lowercase, hyphens, no special chars */
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')  // strip special chars
+    .replace(/[\s_]+/g, '-')        // spaces/underscores → hyphens
+    .replace(/-+/g, '-')            // collapse multiple hyphens
+    .replace(/^-|-$/g, '');         // trim leading/trailing hyphens
+}
+
+const DEFAULT_SCORES: PriorityScores = {
+  blocking: 3,
+  stability: 3,
+  crossImpact: 3,
+  quickWin: 3,
+  complexityInverse: 3,
+};
+
+export async function feedCommand(
+  title: string,
+  options: FeedOptions = {},
+): Promise<void> {
+  const repoPath = process.cwd();
+  const slug = options.slug || slugify(title);
+
+  // Parse --scores JSON override
+  let overrides: Partial<PriorityScores> = {};
+  if (options.scores) {
+    try {
+      overrides = JSON.parse(options.scores);
+      // Validate keys
+      const validKeys = new Set<string>([
+        'blocking', 'stability', 'crossImpact', 'quickWin', 'complexityInverse',
+      ]);
+      for (const key of Object.keys(overrides)) {
+        if (!validKeys.has(key)) {
+          console.error(`❌ Unknown score dimension: "${key}"`);
+          console.error(`   Valid: ${[...validKeys].join(', ')}`);
+          process.exit(1);
+        }
+        const val = (overrides as Record<string, unknown>)[key];
+        if (typeof val !== 'number' || val < 0 || val > 5) {
+          console.error(`❌ Score "${key}" must be a number 0-5, got: ${val}`);
+          process.exit(1);
+        }
+      }
+    } catch (err: any) {
+      if (err.message?.includes('Unknown score') || err.message?.includes('must be a number')) {
+        throw err; // re-throw our own validation errors
+      }
+      console.error(`❌ Invalid --scores JSON: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  const scores: PriorityScores = { ...DEFAULT_SCORES, ...overrides };
+
+  // Ensure tasks file exists
+  await ensureTasksFile(repoPath);
+
+  // Create the task
+  const task = await createWishTask(repoPath, title);
+
+  // Update with priority scores and epic type
+  const updated = await updateTask(repoPath, task.id, {
+    priorityScores: scores,
+    issueType: 'epic',
+  });
+
+  if (!updated) {
+    console.error(`❌ Failed to update task ${task.id} with scores`);
+    process.exit(1);
+  }
+
+  // Compute priority
+  const priority = computePriorityScore(scores);
+
+  // Check for existing brainstorm/wish artifacts
+  const genieDir = getRepoGenieDir(repoPath);
+  const designPath = join(genieDir, 'brainstorms', slug, 'design.md');
+  const wishPath = join(genieDir, 'wishes', slug, 'wish.md');
+  const hasDesign = existsSync(designPath);
+  const hasWish = existsSync(wishPath);
+
+  // Output
+  console.log(`🍽️  Fed: ${updated.id} — "${title}"`);
+  console.log(`   Type:     epic`);
+  console.log(`   Slug:     ${slug}`);
+  console.log(`   Priority: ${priority.toFixed(2)} / 5.00`);
+  console.log(`   Scores:   blocking=${scores.blocking} stability=${scores.stability} cross=${scores.crossImpact} quick=${scores.quickWin} complexity⁻¹=${scores.complexityInverse}`);
+
+  if (hasDesign) console.log(`   📋 Design: .genie/brainstorms/${slug}/design.md`);
+  if (hasWish) console.log(`   📝 Wish:   .genie/wishes/${slug}/wish.md`);
+  if (!hasDesign && !hasWish) console.log(`   💡 No design or wish yet — run: term brainstorm -p "${slug}"`);
+
+  console.log('');
+  console.log(`Next steps:`);
+  console.log(`   term task ls                 - See priority queue`);
+  console.log(`   term work ${updated.id}           - Start working on it`);
+}

--- a/src/term-commands/next.ts
+++ b/src/term-commands/next.ts
@@ -1,0 +1,122 @@
+/**
+ * Next command - Auto-pick highest priority unblocked epic and output contextual prompt
+ *
+ * Usage:
+ *   term next              - Pick top unblocked epic, output skill prompt
+ *   term next <id>         - Pick specific item (bypass queue)
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  listTasks,
+  getTask,
+  computePriorityScore,
+  type LocalTask,
+} from '../lib/local-tasks.js';
+
+export interface NextOptions {
+  json?: boolean;
+}
+
+/**
+ * Determine the current state of an epic and suggest the next skill to run.
+ */
+function detectState(task: LocalTask, repoPath: string): { state: string; skill: string; detail: string } {
+  const slug = extractSlug(task);
+
+  const hasWish = existsSync(join(repoPath, '.genie', 'wishes', slug, 'wish.md'));
+  const hasBrainstorm = existsSync(join(repoPath, '.genie', 'brainstorms', slug, 'design.md'));
+
+  if (hasWish) {
+    // Check wish status
+    try {
+      const wishPath = join(repoPath, '.genie', 'wishes', slug, 'wish.md');
+      const content = readFileSync(wishPath, 'utf-8');
+      const statusMatch = content.match(/\*\*Status:\*\*\s*(\S+)/i);
+      const status = statusMatch?.[1]?.toUpperCase() || 'DRAFT';
+
+      if (status === 'DONE' || status === 'COMPLETE') {
+        return { state: 'done', skill: '/review', detail: `Wish complete — run final review` };
+      }
+      if (status === 'IN_PROGRESS') {
+        return { state: 'working', skill: '/work', detail: `Wish in progress — continue /work` };
+      }
+      // DRAFT or REVIEW
+      return { state: 'wish-ready', skill: '/work', detail: `Wish exists — run /work to execute` };
+    } catch {
+      return { state: 'wish-ready', skill: '/work', detail: `Wish exists — run /work to execute` };
+    }
+  }
+
+  if (hasBrainstorm) {
+    return { state: 'brainstormed', skill: '/wish', detail: `Design exists — run /wish to plan` };
+  }
+
+  return { state: 'raw', skill: '/brainstorm', detail: `No brainstorm yet — run /brainstorm` };
+}
+
+/**
+ * Extract a slug from task title or description.
+ */
+function extractSlug(task: LocalTask): string {
+  // Check description for slug pattern
+  const slugMatch = task.description?.match(/slug:\s*([a-z0-9-]+)/i);
+  if (slugMatch) return slugMatch[1];
+
+  // Slugify title
+  return task.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 64);
+}
+
+export async function nextCommand(target?: string, options: NextOptions = {}): Promise<void> {
+  const repoPath = process.cwd();
+
+  let task: LocalTask | null = null;
+
+  if (target) {
+    // Manual override — pick specific item
+    task = await getTask(repoPath, target);
+    if (!task) {
+      console.error(`❌ Task "${target}" not found.`);
+      process.exit(1);
+    }
+  } else {
+    // Auto-pick: get all tasks, filter to epics, pick top unblocked
+    const allTasks = await listTasks(repoPath);
+    const epics = allTasks.filter(t =>
+      t.issueType === 'epic' &&
+      t.status !== 'done' &&
+      t.status !== 'in_progress'
+    );
+
+    if (epics.length === 0) {
+      console.log('📭 No epics in the queue. Use `term feed "<idea>"` to add one.');
+      return;
+    }
+
+    // listTasks already sorts by priority score
+    task = epics[0];
+  }
+
+  const score = task.priorityScores ? computePriorityScore(task.priorityScores) : 0;
+  const { state, skill, detail } = detectState(task, repoPath);
+
+  if (options.json) {
+    console.log(JSON.stringify({ id: task.id, title: task.title, score, state, skill, detail }, null, 2));
+    return;
+  }
+
+  console.log(`\n🎯 Next: ${task.id} — "${task.title}"`);
+  if (task.priorityScores) {
+    const s = task.priorityScores;
+    console.log(`   Score: ${score.toFixed(2)}/5.00 (B=${s.blocking} S=${s.stability} C=${s.crossImpact} Q=${s.quickWin} X=${s.complexityInverse})`);
+  }
+  console.log(`   State: ${state}`);
+  console.log(`   → ${detail}`);
+  console.log(`\n   Run: ${skill}`);
+  console.log('');
+}

--- a/src/term-commands/score.ts
+++ b/src/term-commands/score.ts
@@ -1,0 +1,103 @@
+/**
+ * Score command - View and update priority scores, trigger Sofia validation
+ *
+ * Usage:
+ *   term score <id>                           - Display scores
+ *   term score <id> --set blocking=5,quickWin=1  - Update specific dimensions
+ *   term score <id> --sofia                   - Trigger Sofia validation (via sessions_send)
+ */
+
+import {
+  getTask,
+  updateTask,
+  computePriorityScore,
+  type PriorityScores,
+} from '../lib/local-tasks.js';
+
+export interface ScoreOptions {
+  set?: string;
+  sofia?: boolean;
+  json?: boolean;
+}
+
+const DIMENSION_LABELS: Record<keyof PriorityScores, string> = {
+  blocking: 'Blocking     (0.30)',
+  stability: 'Stability    (0.25)',
+  crossImpact: 'Cross-impact (0.20)',
+  quickWin: 'Quick-win    (0.15)',
+  complexityInverse: 'Complexity⁻¹ (0.10)',
+};
+
+function renderBar(value: number, max: number = 5): string {
+  const filled = Math.round(value);
+  return '█'.repeat(filled) + '░'.repeat(max - filled);
+}
+
+export async function scoreCommand(taskId: string, options: ScoreOptions = {}): Promise<void> {
+  const repoPath = process.cwd();
+  const task = await getTask(repoPath, taskId);
+
+  if (!task) {
+    console.error(`❌ Task "${taskId}" not found.`);
+    process.exit(1);
+  }
+
+  // Handle --set: update scores
+  if (options.set) {
+    const currentScores: PriorityScores = task.priorityScores || {
+      blocking: 3, stability: 3, crossImpact: 3, quickWin: 3, complexityInverse: 3,
+    };
+
+    const pairs = options.set.split(',');
+    for (const pair of pairs) {
+      const [key, valStr] = pair.split('=');
+      const trimmedKey = key?.trim();
+      const value = Number(valStr?.trim());
+
+      if (!trimmedKey || !(trimmedKey in currentScores)) {
+        console.error(`❌ Unknown dimension: "${trimmedKey}". Valid: ${Object.keys(currentScores).join(', ')}`);
+        process.exit(1);
+      }
+      if (isNaN(value) || value < 0 || value > 5) {
+        console.error(`❌ Score for "${trimmedKey}" must be 0-5 (got ${valStr})`);
+        process.exit(1);
+      }
+      (currentScores as any)[trimmedKey] = value;
+    }
+
+    await updateTask(repoPath, taskId, { priorityScores: currentScores });
+    task.priorityScores = currentScores;
+    console.log(`✅ Scores updated for ${taskId}`);
+  }
+
+  // Handle --sofia: trigger validation
+  if (options.sofia) {
+    console.log(`📡 Sofia validation not yet connected (requires sessions_send integration).`);
+    console.log(`   Manual workaround: ask Sofia to validate these scores.`);
+  }
+
+  // Display scores
+  if (!task.priorityScores) {
+    console.log(`\n📊 ${taskId} — "${task.title}"`);
+    console.log(`   No scores set. Use --set to add: term score ${taskId} --set blocking=4,quickWin=5`);
+    return;
+  }
+
+  const scores = task.priorityScores;
+  const total = computePriorityScore(scores);
+
+  if (options.json) {
+    console.log(JSON.stringify({ id: taskId, title: task.title, scores, priorityScore: total }, null, 2));
+    return;
+  }
+
+  console.log(`\n📊 ${taskId} — "${task.title}"`);
+  console.log(`   PriorityScore: ${total.toFixed(2)}/5.00\n`);
+
+  for (const [key, label] of Object.entries(DIMENSION_LABELS)) {
+    const value = (scores as any)[key] as number;
+    console.log(`   ${label}  ${renderBar(value)} ${value}/5`);
+  }
+
+  console.log('');
+}

--- a/src/term-commands/task/commands.ts
+++ b/src/term-commands/task/commands.ts
@@ -18,6 +18,8 @@ import * as shipCmd from '../ship.js';
 import * as closeCmd from '../close.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { getBackend } from '../../lib/task-backend.js';
+import { listTasks, computePriorityScore, type LocalTask } from '../../lib/local-tasks.js';
 
 const execAsync = promisify(exec);
 
@@ -85,18 +87,58 @@ export function registerTaskNamespace(program: Command): void {
     .option('--all', 'Show all tasks, not just ready')
     .option('--json', 'Output as JSON')
     .action(async (options: { all?: boolean; json?: boolean }) => {
-      try {
-        const cmd = options.all ? 'bd show --all' : 'bd ready';
-        const { stdout } = await execAsync(cmd);
-        console.log(stdout);
-      } catch (error) {
-        const err = error as { stderr?: string };
-        if (err.stderr) {
-          console.error(err.stderr);
-        } else {
-          console.error('Failed to list tasks. Make sure beads (bd) is installed.');
+      const repoPath = process.cwd();
+      const backend = getBackend(repoPath);
+
+      if (backend.kind === 'local') {
+        // Local backend: show tasks sorted by priority score
+        const tasks = await listTasks(repoPath);
+        const filtered = options.all ? tasks : tasks.filter(t => t.status !== 'done');
+
+        if (options.json) {
+          console.log(JSON.stringify(filtered, null, 2));
+          return;
         }
-        process.exit(1);
+
+        if (filtered.length === 0) {
+          console.log('No tasks found. Use `term feed "<idea>"` or `term create "<title>"` to add one.');
+          return;
+        }
+
+        console.log('');
+        console.log('┌────────────┬──────┬────────────┬───────┬──────────────────────────────────────────────────┐');
+        console.log('│ ID         │ Type │ Status     │ Score │ Title                                            │');
+        console.log('├────────────┼──────┼────────────┼───────┼──────────────────────────────────────────────────┤');
+
+        for (const task of filtered) {
+          const id = task.id.padEnd(10).substring(0, 10);
+          const type = (task.issueType === 'epic' ? 'epic' : 'task').padEnd(4);
+          const statusEmoji = task.status === 'done' ? '✅' : task.status === 'in_progress' ? '🔄' : task.status === 'blocked' ? '🔴' : '⚪';
+          const status = `${statusEmoji} ${task.status}`.padEnd(10).substring(0, 10);
+          const score = task.priorityScores
+            ? computePriorityScore(task.priorityScores).toFixed(1).padStart(5)
+            : '  —  ';
+          const title = task.title.padEnd(48).substring(0, 48);
+          console.log(`│ ${id} │ ${type} │ ${status} │ ${score} │ ${title} │`);
+        }
+
+        console.log('└────────────┴──────┴────────────┴───────┴──────────────────────────────────────────────────┘');
+        console.log('');
+      } else {
+        // Beads backend: delegate to bd
+        try {
+          const cmd = options.all ? 'bd show --all' : 'bd ready';
+          const { stdout } = await execAsync(cmd);
+          console.log(stdout);
+        } catch (error) {
+          const err = error as { stderr?: string };
+          if (err.stderr) {
+            console.error(err.stderr);
+          } else {
+            console.error('Failed to list tasks. Make sure beads (bd) is installed.');
+          }
+          process.exit(1);
+        }
       }
     });
 

--- a/src/term.ts
+++ b/src/term.ts
@@ -35,6 +35,9 @@ import * as batchCmd from './term-commands/batch.js';
 import * as councilCmd from './term-commands/council.js';
 import * as resolveCmd from './term-commands/resolve.js';
 import * as historyCmd from './term-commands/history.js';
+import * as feedCmd from './term-commands/feed.js';
+import * as nextCmd from './term-commands/next.js';
+import * as scoreCmd from './term-commands/score.js';
 import { registerSessionNamespace } from './term-commands/session/commands.js';
 import { registerTaskNamespace } from './term-commands/task/commands.js';
 import { registerWishNamespace } from './term-commands/wish/commands.js';
@@ -368,6 +371,36 @@ program
   .option('--json', 'Output as JSON')
   .action(async (title: string, options: createCmd.CreateOptions) => {
     await createCmd.createCommand(title, options);
+  });
+
+// Feed backlog item as scored epic
+program
+  .command('feed <title>')
+  .description('Ingest a backlog item as a scored epic')
+  .option('--scores <json>', 'Override scoring dimensions (JSON)')
+  .option('--slug <slug>', 'Custom slug (default: slugified title)')
+  .action(async (title: string, options: feedCmd.FeedOptions) => {
+    await feedCmd.feedCommand(title, options);
+  });
+
+// Auto-pick next priority item
+program
+  .command('next [target]')
+  .description('Auto-pick highest priority unblocked epic and suggest next action')
+  .option('--json', 'Output as JSON')
+  .action(async (target: string | undefined, options: nextCmd.NextOptions) => {
+    await nextCmd.nextCommand(target, options);
+  });
+
+// View and update priority scores
+program
+  .command('score <task-id>')
+  .description('View and update priority scores for a task')
+  .option('--set <dims>', 'Set dimensions (e.g., blocking=5,quickWin=1)')
+  .option('--sofia', 'Trigger Sofia validation')
+  .option('--json', 'Output as JSON')
+  .action(async (taskId: string, options: scoreCmd.ScoreOptions) => {
+    await scoreCmd.scoreCommand(taskId, options);
   });
 
 // Worker management commands (beads + Claude orchestration)


### PR DESCRIPTION
## Priority Queue — Live Backlog That Feeds the Framework

Adds priority scoring and auto-picking to genie-cli's task infrastructure.

### New Commands
- **`term feed "<idea>"`** — Ingest backlog item as scored epic (default 3/5 all dimensions, `--scores` JSON override)
- **`term next`** — Auto-pick highest priority unblocked epic, detect state, suggest next skill (/brainstorm → /wish → /work → /review)
- **`term score <id>`** — View/update priority scores per dimension (`--set blocking=5,quickWin=1`), Sofia placeholder

### Infrastructure
- `PriorityScores` interface (5 dimensions × 0-5 scale)
- `computePriorityScore()` weighted formula: B×0.30 + S×0.25 + C×0.20 + Q×0.15 + X×0.10
- `LocalTask` extended with `priorityScores?` and `issueType?` ('task' | 'epic')
- `getQueue()` and `listTasks()` sort by PriorityScore DESC
- `term task ls` now shows score column, type badges, sorted output (local backend)

### Tests
- 19/19 passing (scoring math, queue sorting, score-vs-no-score ordering)

### Review
- Subagent review: **SHIP ✅** — all acceptance criteria met
- Sofia placeholder acknowledged (degraded mode per wish ASM-2)

Wish: `.genie/wishes/priority-queue/wish.md`
Design: `.genie/brainstorms/priority-queue/design.md`