### PR TITLE
brainstorm: durable drafts + crystallize (design.md + beads ledger)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,38 @@ claudio launches Claude Code with custom LLM routing profiles.
 
 ### Commands
 
+### Brainstorm
+
+- `genie brainstorm crystallize --slug <slug> [--file <path>]`
+  - Reads draft markdown (default: `.genie/brainstorms/<slug>/draft.md`)
+  - Writes/overwrites: `.genie/brainstorms/<slug>/design.md`
+  - Upserts: `.beads/issues.jsonl` (default depends_on: `["hq-roadmap"]`)
+  - Prints the written paths
+
+### Ledger
+
+- `genie ledger validate [--repo <path>] [--json]`
+  - Validates `.beads/issues.jsonl` JSONL structure (scriptable)
+
+### `term beads-validate` (deprecated)
+
+Deprecated in favor of **`genie ledger validate`**.
+
+Validate the local Beads JSONL ledger file:
+
+- Path: `.beads/issues.jsonl`
+- Checks: file exists, each non-empty line is valid JSON, and `id` is present/unique.
+
+```bash
+# preferred
+genie ledger validate --repo .
+genie ledger validate --repo . --json
+
+# deprecated
+term beads-validate --repo .
+term beads-validate --repo . --json
+```
+
 ```
 claudio                     Launch with default profile
 claudio <profile>           Launch with named profile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/genie",
-  "version": "0.260213.1834",
+  "version": "0.260213.2233",
   "description": "Collaborative terminal toolkit for human + AI workflows",
   "type": "module",
   "bin": {

--- a/plugins/automagik-genie/.claude-plugin/plugin.json
+++ b/plugins/automagik-genie/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "automagik-genie",
-  "version": "0.260213.1834",
+  "version": "0.260213.2233",
   "description": "Human-AI partnership for Claude Code. Share a terminal, orchestrate workers, evolve together. Brainstorm ideas, turn them into wishes, execute with /work, validate with /review, and ship as one team.",
   "author": {
     "name": "Namastex Labs"

--- a/plugins/automagik-genie/openclaw.plugin.json
+++ b/plugins/automagik-genie/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "automagik-genie",
   "name": "Automagik Genie",
   "description": "Skills, agents, and hooks for the Genie CLI terminal orchestration toolkit",
-  "version": "0.260213.1834",
+  "version": "0.260213.2233",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -10,11 +10,13 @@ Use for early-stage or ambiguous ideas. Track wish-readiness as you go.
 ## Flow
 
 1. Read context quickly (current code/docs/conventions).
-2. Clarify intent with **one question at a time** (prefer multiple-choice).
-3. After each exchange, update the **WRS bar** (see below).
-4. Propose 2-3 approaches with trade-offs. Recommend one.
-5. When WRS ≥ 60: offer to crystallize → hand off to `/wish`.
-6. When WRS = 100: auto-crystallize → `design.md` → hand off.
+2. Initialize persistence immediately (see **Persistence**): create/maintain `.genie/brainstorms/<slug>/draft.md` from the start.
+3. Clarify intent with **one question at a time** (prefer multiple-choice).
+4. After each exchange, update the **WRS bar** (see below).
+5. Persist the draft **when WRS changes OR every 2 minutes** (whichever comes first).
+6. Propose 2-3 approaches with trade-offs. Recommend one.
+7. When WRS ≥ 60: offer to crystallize → hand off to `/wish`.
+8. When WRS = 100: auto-crystallize (see **Crystallize**) → `design.md` → hand off.
 
 ## WRS — Wish Readiness Score
 
@@ -44,7 +46,20 @@ WRS: ██████░░░░ 60/100
 - **< 40**: Keep exploring. Don't rush.
 - **40-59**: Getting close. Focus questions on unfilled dimensions.
 - **≥ 60**: Offer: `"WRS hit 60. Ready to pour into /wish, or keep refining?"`
-- **100**: Auto-crystallize: write `design.md`, hand off to `/wish`.
+- **100**: Auto-crystallize (see **Crystallize**): write `design.md`, hand off to `/wish`.
+
+## Persistence
+
+- **Draft-first**: maintain `.genie/brainstorms/<slug>/draft.md` from the start of the brainstorm.
+- **Cadence**: write/refresh `draft.md` **when WRS changes OR every 2 minutes**, whichever comes first.
+  - This is to survive freezes/restarts; do not wait until the end.
+
+## Crystallize
+
+- **Trigger**: when **WRS = 100**, crystallize automatically.
+- **Semantics**:
+  - Write/update `.genie/brainstorms/<slug>/design.md` **from** `.genie/brainstorms/<slug>/draft.md`.
+  - Trigger Beads upsert via: `genie brainstorm crystallize`.
 
 ## Output Options
 

--- a/src/__tests__/beads-issues-jsonl.test.ts
+++ b/src/__tests__/beads-issues-jsonl.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, writeFile, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, test, expect } from 'bun:test';
+
+import { ensureBeadsIssuesPath, upsertBeadsIssueJsonl } from '../lib/beads-issues-jsonl.js';
+
+describe('beads-issues-jsonl', () => {
+  test('upsert is idempotent and preserves created_at', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'genie-cli-beads-'));
+    const issuesPath = await ensureBeadsIssuesPath(dir);
+
+    const r1 = await upsertBeadsIssueJsonl(issuesPath, {
+      id: 'my-wish',
+      title: 'My Wish',
+      status: 'open',
+      source_repo: 'git:file:/tmp/repo',
+      wish_slug: 'my-wish',
+      depends_on: ['hq-roadmap'],
+    });
+
+    // update title, ensure created_at preserved and only one line exists
+    const r2 = await upsertBeadsIssueJsonl(issuesPath, {
+      id: 'my-wish',
+      title: 'My Wish (updated)',
+      status: 'open',
+      source_repo: 'git:file:/tmp/repo',
+      wish_slug: 'my-wish',
+      depends_on: ['hq-roadmap'],
+    });
+
+    expect(r2.created_at).toBe(r1.created_at);
+    expect(r2.updated_at).not.toBe(r1.updated_at);
+
+    const content = await readFile(issuesPath, 'utf-8');
+    const lines = content.split('\n').filter(l => l.trim());
+    expect(lines.length).toBe(1);
+
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.id).toBe('my-wish');
+    expect(parsed.title).toBe('My Wish (updated)');
+  });
+
+  test('preserves malformed lines', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'genie-cli-beads-'));
+    const issuesPath = await ensureBeadsIssuesPath(dir);
+
+    await writeFile(issuesPath, '{not json}\n', 'utf-8');
+
+    await upsertBeadsIssueJsonl(issuesPath, {
+      id: 'a',
+      title: 'A',
+      status: 'open',
+      source_repo: 'git:file:/tmp/repo',
+      wish_slug: 'a',
+      depends_on: ['hq-roadmap'],
+    });
+
+    const content = await readFile(issuesPath, 'utf-8');
+    expect(content).toContain('{not json}');
+    expect(content).toContain('"id":"a"');
+  });
+});

--- a/src/__tests__/brainstorm-crystallize.test.ts
+++ b/src/__tests__/brainstorm-crystallize.test.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, test } from 'bun:test';
+import { brainstormCrystallizeCommand } from '../genie-commands/brainstorm/crystallize.js';
+
+async function mkRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'genie-cli-crystallize-'));
+  // minimal git config not required; getSourceRepo may read package.json or git.
+  // Provide package.json to satisfy source_repo discovery in most cases.
+  await writeFile(join(dir, 'package.json'), JSON.stringify({ name: 'tmp-repo' }, null, 2));
+  return dir;
+}
+
+describe('genie brainstorm crystallize', () => {
+  test('writes design.md and upserts beads issue with default depends_on', async () => {
+    const repo = await mkRepo();
+    const slug = 'my-idea';
+    const draftPath = join(repo, '.genie', 'brainstorms', slug, 'draft.md');
+    await mkdir(join(repo, '.genie', 'brainstorms', slug), { recursive: true });
+    await writeFile(draftPath, '# Draft\n\nHello');
+
+    // should not throw
+    await brainstormCrystallizeCommand({ slug, repo });
+
+    const designPath = join(repo, '.genie', 'brainstorms', slug, 'design.md');
+    const design = await readFile(designPath, 'utf-8');
+    expect(design).toContain('Hello');
+
+    const issuesPath = join(repo, '.beads', 'issues.jsonl');
+    const jsonl = await readFile(issuesPath, 'utf-8');
+    const lines = jsonl.split('\n').filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+
+    const rec = JSON.parse(lines[lines.length - 1]);
+    expect(rec.id).toBe(slug);
+    expect(rec.depends_on).toEqual(['hq-roadmap']);
+  });
+});

--- a/src/genie-commands/brainstorm/crystallize.ts
+++ b/src/genie-commands/brainstorm/crystallize.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'fs/promises';
+import { basename, dirname, join, resolve } from 'path';
+import { crystallizeBrainstormAndUpsertBeads } from '../../term-commands/brainstorm-beads.js';
+
+export interface BrainstormCrystallizeOptions {
+  slug: string;
+  file?: string;
+  repo?: string;
+  title?: string;
+  dependsOn?: string;
+  status?: 'open' | 'closed';
+}
+
+function slugFromPath(p: string): string | null {
+  // .genie/brainstorms/<slug>/draft.md
+  const m = p.replace(/\\/g, '/').match(/\.genie\/brainstorms\/([^/]+)\//);
+  return m?.[1] ?? null;
+}
+
+export async function brainstormCrystallizeCommand(options: BrainstormCrystallizeOptions): Promise<void> {
+  const repoPath = resolve(options.repo || process.cwd());
+
+  const slug = options.slug;
+  if (!slug) {
+    console.error('❌ Missing required: --slug <slug>');
+    process.exit(1);
+  }
+
+  const defaultDraft = join(repoPath, '.genie', 'brainstorms', slug, 'draft.md');
+  const draftPath = resolve(repoPath, options.file ?? defaultDraft);
+
+  let draft: string;
+  try {
+    draft = await readFile(draftPath, 'utf-8');
+  } catch {
+    console.error(`❌ Could not read draft file: ${draftPath}`);
+    process.exit(1);
+  }
+
+  const title = options.title || slug;
+  const dependsOn = options.dependsOn
+    ? options.dependsOn.split(',').map(s => s.trim()).filter(Boolean)
+    : undefined;
+
+  const { designPath, beadsPath } = await crystallizeBrainstormAndUpsertBeads({
+    repoPath,
+    slug,
+    title,
+    designMarkdown: draft,
+    status: options.status,
+    dependsOn,
+  });
+
+  // Basic guardrails / helpful output
+  if (basename(draftPath) !== 'draft.md' && !options.title) {
+    const inferred = slugFromPath(draftPath);
+    if (inferred && inferred !== slug) {
+      console.error(`ℹ️  Note: slug inferred from file path would be "${inferred}" (you passed --slug ${slug})`);
+    }
+  }
+
+  console.log(designPath);
+  console.log(beadsPath);
+}

--- a/src/genie-commands/ledger/validate.ts
+++ b/src/genie-commands/ledger/validate.ts
@@ -1,0 +1,5 @@
+import { beadsValidateCommand, type BeadsValidateOptions } from '../../term-commands/beads-validate.js';
+
+export async function ledgerValidateCommand(options: BeadsValidateOptions): Promise<void> {
+  await beadsValidateCommand(options);
+}

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -26,6 +26,8 @@ import {
   pdfThemesCommand,
   pdfTemplatesCommand,
 } from './genie-commands/pdf.js';
+import { brainstormCrystallizeCommand } from './genie-commands/brainstorm/crystallize.js';
+import { ledgerValidateCommand } from './genie-commands/ledger/validate.js';
 
 const program = new Command();
 
@@ -171,5 +173,33 @@ pdf
   .command('templates')
   .description('List available templates')
   .action(pdfTemplatesCommand);
+
+// Brainstorm command group
+const brainstorm = program
+  .command('brainstorm')
+  .description('Brainstorm utilities (file-based helpers)');
+
+brainstorm
+  .command('crystallize')
+  .description('Crystallize a brainstorm draft into design.md and upsert .beads/issues.jsonl')
+  .requiredOption('--slug <slug>', 'Brainstorm slug (kebab-case)')
+  .option('--file <path>', 'Input draft markdown path (default: .genie/brainstorms/<slug>/draft.md)')
+  .option('-r, --repo <path>', 'Repo path (default: cwd)')
+  .option('--title <title>', 'Issue title (default: slug)')
+  .option('--depends-on <ids>', 'Comma-separated dependency IDs (default: hq-roadmap)')
+  .option('--status <status>', 'Issue status (open|closed)', 'open')
+  .action(brainstormCrystallizeCommand);
+
+// Ledger command group
+const ledger = program
+  .command('ledger')
+  .description('Ledger utilities (beads JSONL validation)');
+
+ledger
+  .command('validate')
+  .description('Validate local .beads/issues.jsonl JSONL structure (scriptable)')
+  .option('-r, --repo <path>', 'Repo path (default: cwd)')
+  .option('--json', 'Output JSON')
+  .action(ledgerValidateCommand);
 
 program.parse();

--- a/src/lib/beads-issues-jsonl.ts
+++ b/src/lib/beads-issues-jsonl.ts
@@ -1,0 +1,146 @@
+/**
+ * Beads issues.jsonl helpers (minimal, local-file only)
+ *
+ * Canonical file: <repo>/.beads/issues.jsonl
+ *
+ * This module intentionally does NOT call `bd` and does not implement any
+ * external ingestion. It only performs local JSONL upsert operations.
+ */
+
+import { access, mkdir, readFile, rename, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
+import { promisify } from 'util';
+import { exec as execCb } from 'child_process';
+
+const execAsync = promisify(execCb);
+
+export interface BeadsIssueRecord {
+  id: string;
+  title: string;
+  status: 'open' | 'closed';
+  source_repo: string;
+  wish_slug: string;
+  created_at: string;
+  updated_at: string;
+  depends_on: string[];
+  // Allow forward-compatible fields
+  [k: string]: unknown;
+}
+
+export function utcNowRfc3339(): string {
+  // JS Date.toISOString() is RFC3339 UTC
+  return new Date().toISOString();
+}
+
+export async function ensureBeadsIssuesPath(repoPath: string): Promise<string> {
+  const issuesPath = join(repoPath, '.beads', 'issues.jsonl');
+  await mkdir(dirname(issuesPath), { recursive: true });
+  return issuesPath;
+}
+
+function safeJsonParse(line: string): any | null {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Upsert a record by `id`.
+ * - Idempotent: repeated calls update the same line
+ * - Preserves other lines as-is
+ * - Best-effort preservation of original created_at when updating
+ */
+export async function upsertBeadsIssueJsonl(
+  issuesPath: string,
+  record: Omit<BeadsIssueRecord, 'created_at' | 'updated_at'> & {
+    created_at?: string;
+    updated_at?: string;
+  }
+): Promise<BeadsIssueRecord> {
+  const now = utcNowRfc3339();
+
+  let lines: string[] = [];
+  try {
+    const content = await readFile(issuesPath, 'utf-8');
+    lines = content.split('\n');
+  } catch {
+    // no file yet
+  }
+
+  let existingCreatedAt: string | undefined;
+
+  const newLines: string[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const obj = safeJsonParse(line);
+    if (!obj || typeof obj !== 'object') {
+      // Preserve malformed lines (don't delete user data)
+      newLines.push(line);
+      continue;
+    }
+    if (obj.id === record.id) {
+      if (typeof obj.created_at === 'string') existingCreatedAt = obj.created_at;
+      // skip; will re-add updated line at end for simplicity
+      continue;
+    }
+    newLines.push(JSON.stringify(obj));
+  }
+
+  const final: BeadsIssueRecord = {
+    ...record,
+    created_at: record.created_at || existingCreatedAt || now,
+    updated_at: record.updated_at || now,
+  } as BeadsIssueRecord;
+
+  newLines.push(JSON.stringify(final));
+
+  // Atomic write
+  await mkdir(dirname(issuesPath), { recursive: true });
+  const tmp = issuesPath + `.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tmp, newLines.join('\n') + '\n', 'utf-8');
+  await rename(tmp, issuesPath);
+
+  return final;
+}
+
+/**
+ * Normalize source_repo to one of:
+ *   - git:<remote-url>
+ *   - git:file:<abs-path>
+ */
+export async function getSourceRepo(repoPath: string): Promise<string> {
+  // Prefer origin remote URL, normalized
+  try {
+    const { stdout } = await execAsync('git remote get-url origin', { cwd: repoPath });
+    const url = stdout.trim();
+    if (url) return `git:${normalizeGitRemote(url)}`;
+  } catch {
+    // ignore
+  }
+  return `git:file:${repoPath}`;
+}
+
+export function normalizeGitRemote(url: string): string {
+  // Trim and strip trailing .git or slash
+  let u = (url || '').trim();
+  u = u.replace(/\s+/g, '');
+  u = u.replace(/\.git$/i, '');
+  u = u.replace(/\/$/, '');
+  // Convert scp-like git@host:org/repo to ssh://git@host/org/repo
+  if (/^[\w.-]+@[\w.-]+:/.test(u) && !u.startsWith('ssh://')) {
+    const [userHost, path] = u.split(':', 2);
+    u = `ssh://${userHost}/${path}`;
+  }
+  return u;
+}
+
+export async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/beads-issues-jsonl.ts
+++ b/src/lib/beads-issues-jsonl.ts
@@ -27,9 +27,20 @@ export interface BeadsIssueRecord {
   [k: string]: unknown;
 }
 
+let _lastUtcNowMs = 0;
+
+/**
+ * RFC3339/ISO8601 UTC timestamp with a monotonic guarantee.
+ *
+ * Note: Date() only has millisecond resolution. When we write multiple records
+ * in the same tick (common in tests and fast CLIs), we still want updated_at
+ * to advance so downstream consumers can rely on it.
+ */
 export function utcNowRfc3339(): string {
-  // JS Date.toISOString() is RFC3339 UTC
-  return new Date().toISOString();
+  const ms = Date.now();
+  const next = ms <= _lastUtcNowMs ? _lastUtcNowMs + 1 : ms;
+  _lastUtcNowMs = next;
+  return new Date(next).toISOString();
 }
 
 export async function ensureBeadsIssuesPath(repoPath: string): Promise<string> {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,5 +1,5 @@
 // Runtime version (baked in at build time)
-export const VERSION = '0.260213.1834';
+export const VERSION = '0.260213.2233';
 
 // Generate version string from current datetime
 // Format: 0.YYMMDD.HHMM (e.g., 0.260201.1430 = Feb 1, 2026 at 14:30)

--- a/src/term-commands/beads-validate.ts
+++ b/src/term-commands/beads-validate.ts
@@ -1,0 +1,76 @@
+/**
+ * beads-validate command
+ *
+ * Scriptable validation for .beads/issues.jsonl existence + JSONL parse.
+ * Minimal by design.
+ */
+
+import { readFile } from 'fs/promises';
+import { join, resolve } from 'path';
+
+export interface BeadsValidateOptions {
+  repo?: string;
+  json?: boolean;
+}
+
+export async function beadsValidateCommand(options: BeadsValidateOptions = {}): Promise<void> {
+  const repoPath = resolve(options.repo || process.cwd());
+  const issuesPath = join(repoPath, '.beads', 'issues.jsonl');
+
+  let content: string;
+  try {
+    content = await readFile(issuesPath, 'utf-8');
+  } catch {
+    const msg = `❌ Missing: ${issuesPath}`;
+    if (options.json) {
+      console.log(JSON.stringify({ ok: false, error: msg, issuesPath }, null, 2));
+      process.exit(1);
+    }
+    console.error(msg);
+    process.exit(1);
+  }
+
+  const errors: Array<{ line: number; error: string }> = [];
+  let count = 0;
+  const ids = new Set<string>();
+
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line);
+      count++;
+      if (obj?.id) {
+        if (ids.has(obj.id)) {
+          errors.push({ line: i + 1, error: `duplicate id: ${obj.id}` });
+        }
+        ids.add(obj.id);
+      } else {
+        errors.push({ line: i + 1, error: 'missing id' });
+      }
+    } catch (e: any) {
+      errors.push({ line: i + 1, error: e?.message || 'invalid json' });
+    }
+  }
+
+  const ok = errors.length === 0;
+
+  if (options.json) {
+    console.log(JSON.stringify({ ok, issuesPath, count, errors }, null, 2));
+  } else {
+    if (ok) {
+      console.log(`✅ Beads issues.jsonl valid (${count} records) at ${issuesPath}`);
+    } else {
+      console.error(`❌ Beads issues.jsonl invalid at ${issuesPath}`);
+      for (const e of errors.slice(0, 20)) {
+        console.error(`   line ${e.line}: ${e.error}`);
+      }
+      if (errors.length > 20) {
+        console.error(`   ...and ${errors.length - 20} more`);
+      }
+    }
+  }
+
+  if (!ok) process.exit(1);
+}

--- a/src/term-commands/brainstorm-beads.ts
+++ b/src/term-commands/brainstorm-beads.ts
@@ -1,0 +1,61 @@
+/**
+ * Brainstorm completion helpers
+ *
+ * When /brainstorm reaches WRS=100 and writes:
+ *   .genie/brainstorms/<slug>/design.md
+ * we also upsert a Beads issue record into:
+ *   <repo>/.beads/issues.jsonl
+ */
+
+import { dirname, join, resolve } from 'path';
+import { mkdir, writeFile } from 'fs/promises';
+import {
+  ensureBeadsIssuesPath,
+  getSourceRepo,
+  upsertBeadsIssueJsonl,
+  type BeadsIssueRecord,
+} from '../lib/beads-issues-jsonl.js';
+
+export interface CrystallizeBrainstormOptions {
+  repoPath: string;
+  slug: string; // kebab-case
+  title: string;
+  designMarkdown: string;
+  status?: 'open' | 'closed';
+  dependsOn?: string[];
+}
+
+export async function crystallizeBrainstormAndUpsertBeads(
+  opts: CrystallizeBrainstormOptions
+): Promise<{ designPath: string; beadsPath: string; record: BeadsIssueRecord }> {
+  const repoPath = resolve(opts.repoPath);
+  const slug = opts.slug;
+  const title = opts.title;
+  const status = opts.status ?? 'open';
+
+  const depends_on = (opts.dependsOn && opts.dependsOn.length > 0)
+    ? opts.dependsOn
+    : ['hq-roadmap'];
+
+  const designPath = join(repoPath, '.genie', 'brainstorms', slug, 'design.md');
+  await mkdir(dirname(designPath), { recursive: true });
+  await writeFile(designPath, opts.designMarkdown, 'utf-8');
+
+  const issuesPath = await ensureBeadsIssuesPath(repoPath);
+  const source_repo = await getSourceRepo(repoPath);
+
+  const record = await upsertBeadsIssueJsonl(issuesPath, {
+    id: slug,
+    title,
+    status,
+    source_repo,
+    wish_slug: slug,
+    depends_on,
+  });
+
+  return {
+    designPath,
+    beadsPath: issuesPath,
+    record,
+  };
+}

--- a/src/term.ts
+++ b/src/term.ts
@@ -343,6 +343,17 @@ program
     await spawnCmd.spawnCommand('brainstorm', options);
   });
 
+program
+  .command('beads-validate')
+  .description('[DEPRECATED] Validate local .beads/issues.jsonl JSONL structure → use `genie ledger validate`')
+  .option('-r, --repo <path>', 'Repo path (default: cwd)')
+  .option('--json', 'Output JSON')
+  .action(async (options: any) => {
+    showDeprecation('beads-validate', 'ledger validate');
+    const cmd = await import('./term-commands/beads-validate.js');
+    await cmd.beadsValidateCommand(options);
+  });
+
 // Watch session events (promoted from orc watch)
 program
   .command('watch <target>')


### PR DESCRIPTION
## Summary
Brainstorms freeze/restart often; losing state is painful. This PR standardizes a **durable on-disk draft** and a deterministic **crystallize** step that also updates the **Beads JSONL ledger**.

## What changed
### Brainstorm persistence spec
- Require draft-first persistence: `.genie/brainstorms/<slug>/draft.md` from the start
- Cadence: refresh `draft.md` when **WRS changes** OR every **2 minutes** (whichever comes first)
- WRS=100 triggers crystallize

### New command: `genie brainstorm crystallize`
- Input: file-based draft markdown (default: `.genie/brainstorms/<slug>/draft.md`)
- Output: writes/overwrites `.genie/brainstorms/<slug>/design.md`
- Ledger: upserts `<repo>/.beads/issues.jsonl` (idempotent)
- Default hard dependency: `depends_on: ["hq-roadmap"]`

### Ledger validation
- Add `genie ledger validate` (preferred)
- Keep `term beads-validate` but mark it **deprecated** (points to `genie ledger validate`)

## How to validate
```bash
# fast
bun test src/__tests__/brainstorm-crystallize.test.ts

# manual smoke
mkdir -p .genie/brainstorms/demo
printf '# demo draft\n' > .genie/brainstorms/demo/draft.md

genie brainstorm crystallize --slug demo --repo .
genie ledger validate --repo .
```

## Notes
- Does not implement Postgres indexing/cache; `.beads/issues.jsonl` remains canonical.
