### PR TITLE
ci: fleet update uses install.sh --local (fix stale OpenClaw plugin paths)

### DIFF
--- a/Jenkinsfile.fleet-cli
+++ b/Jenkinsfile.fleet-cli
@@ -39,28 +39,16 @@ git fetch origin +refs/heads/main:refs/remotes/origin/main
 git checkout -B main refs/remotes/origin/main
 git reset --hard refs/remotes/origin/main
 
+# Run official installer in local mode (source-of-truth)
+# This also repairs stale OpenClaw plugin paths in ~/.openclaw/openclaw.json
+# and ensures prerequisites like jq/rg are installed (best-effort).
+#
+# NOTE: install.sh is interactive; in CI we default answers to yes.
 export PATH="${HOME}/.bun/bin:${BIN_DIR}:/usr/local/bin:${PATH}"
-command -v bun >/dev/null || { echo "ERROR: bun not found"; exit 3; }
 
-bun install --frozen-lockfile 2>/dev/null || bun install
-bun run build
-
-# ── Create bash wrappers (NOT symlinks, NOT bun link) ──
-# bun link creates fragile global symlinks that break across hosts.
-# Bash wrappers are durable and resolve the correct bun + dist path.
-for cmd in genie term; do
-    DIST_FILE="${REPO_DIR}/dist/${cmd}.js"
-    WRAPPER="${BIN_DIR}/${cmd}"
-    if [ -f "${DIST_FILE}" ]; then
-        # Remove any existing symlink or stale wrapper
-        rm -f "${WRAPPER}"
-        cat > "${WRAPPER}" << WRAP
-#!/usr/bin/env bash
-exec "${HOME}/.bun/bin/bun" "${DIST_FILE}" "\$@"
-WRAP
-        chmod +x "${WRAPPER}"
-    fi
-done
+# Use yes to avoid hanging on prompts in non-interactive Jenkins runs.
+# If a host requires sudo for prereqs, the installer will fail fast.
+yes | bash "${REPO_DIR}/install.sh" --local "${REPO_DIR}" || { echo "ERROR: install.sh failed"; exit 5; }
 
 GENIE_VER="$(genie --version 2>/dev/null || echo 'unknown')"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"

--- a/Jenkinsfile.fleet-cli
+++ b/Jenkinsfile.fleet-cli
@@ -47,6 +47,12 @@ git reset --hard refs/remotes/origin/main
 export PATH="${HOME}/.bun/bin:${BIN_DIR}:/usr/local/bin:${PATH}"
 
 # Use yes to avoid hanging on prompts in non-interactive Jenkins runs.
+
+# Preflight: fail fast if required baseline tools are missing (avoid sudo prompts/hangs).
+for bin in git jq rg tmux; do
+  command -v "" >/dev/null 2>&1 || { echo "ERROR: missing prerequisite: "; exit 3; }
+done
+
 # If a host requires sudo for prereqs, the installer will fail fast.
 yes | bash "${REPO_DIR}/install.sh" --local "${REPO_DIR}" || { echo "ERROR: install.sh failed"; exit 5; }
 


### PR DESCRIPTION
This updates Jenkinsfile.fleet-cli to run the official genie-cli install.sh in --local mode on each fleet host.

Benefits:
- Uses the canonical installer workflow.
- Repairs stale OpenClaw plugin paths in ~/.openclaw/openclaw.json (fixes /wish, /review skill ENOENT issues caused by moved workspaces).
- Avoids custom wrapper generation drifting from installer behavior.

Note: install.sh is interactive; Jenkins runs it via `yes | ...` to avoid hanging.