### PR TITLE
ci: split fleet jobs — remove OpenClaw restart/broadcast from genie-cli job

### DIFF
--- a/Jenkinsfile.fleet-cli
+++ b/Jenkinsfile.fleet-cli
@@ -141,23 +141,6 @@ echo "BROADCAST_OK: ${HOST_LABEL}"
                 stage('omni-prod') { steps { updateHost('omni@10.114.1.140', 'omni-prod') } }
             }
         }
-
-        stage('Restart Gateways') {
-            parallel {
-                stage('genie-os restart')  { steps { restartGateway('genie@10.114.1.111', 'genie-os') } }
-                stage('cegonha restart')   { steps { restartGateway('genie@10.114.1.121', 'cegonha') } }
-                stage('stefani restart')   { steps { restartGateway('genie@10.114.1.124', 'stefani') } }
-                stage('gus restart')       { steps { restartGateway('genie@10.114.1.126', 'gus') } }
-                stage('luis restart')      { steps { restartGateway('genie@10.114.1.131', 'luis') } }
-                stage('sampaio restart')   { steps { restartGateway('genie@10.114.1.154', 'sampaio') } }
-                stage('juice restart')     { steps { restartGateway('openclaw@10.114.1.119', 'juice') } }
-                stage('omni-prod restart') { steps { restartGateway('omni@10.114.1.140', 'omni-prod') } }
-            }
-        }
-
-        stage('Broadcast Update to Agents') {
-            parallel {
-                stage('genie-os notify')  { steps { broadcastUpdate('genie@10.114.1.111', 'genie-os') } }
                 stage('cegonha notify')   { steps { broadcastUpdate('genie@10.114.1.121', 'cegonha') } }
                 stage('stefani notify')   { steps { broadcastUpdate('genie@10.114.1.124', 'stefani') } }
                 stage('gus notify')       { steps { broadcastUpdate('genie@10.114.1.126', 'gus') } }
@@ -178,19 +161,5 @@ def updateHost(String sshTarget, String hostLabel) {
     sh """
         echo 'Updating genie-cli on ${hostLabel} (${sshTarget})...'
         cat update-genie-cli.sh | ssh -o BatchMode=yes -o ConnectTimeout=20 ${sshTarget} 'bash -s -- ${hostLabel}'
-    """
-}
-
-def restartGateway(String sshTarget, String hostLabel) {
-    sh """
-        echo 'Restarting gateway on ${hostLabel} (${sshTarget})...'
-        cat restart-gateway.sh | ssh -o BatchMode=yes -o ConnectTimeout=20 ${sshTarget} 'bash -s -- ${hostLabel}'
-    """
-}
-
-def broadcastUpdate(String sshTarget, String hostLabel) {
-    sh """
-        echo 'Broadcasting update notification on ${hostLabel} (${sshTarget})...'
-        cat broadcast-update.sh | ssh -o BatchMode=yes -o ConnectTimeout=20 ${sshTarget} 'bash -s -- ${hostLabel} "${BUILD_URL}" "${BUILD_NUMBER}"'
     """
 }


### PR DESCRIPTION
This makes genie-cli-fleet-update a single-project job: it only updates genie-cli (via install.sh --local + prereq preflight).\n\nRemoved from Jenkinsfile.fleet-cli:\n- Restart Gateways stage (openclaw gateway restart)\n- Broadcast Update to Agents stage (openclaw system event)\n- restart-gateway.sh and broadcast-update.sh generation\n\nRationale: OpenClaw failures should not mark genie-cli deploys as failed. OpenClaw should have its own fleet job using its official installer.