### PR TITLE
ci: fix fleet preflight (explicit checks; avoids empty command -v)

### DIFF
--- a/Jenkinsfile.fleet-cli
+++ b/Jenkinsfile.fleet-cli
@@ -49,9 +49,10 @@ export PATH="${HOME}/.bun/bin:${BIN_DIR}:/usr/local/bin:${PATH}"
 # Use yes to avoid hanging on prompts in non-interactive Jenkins runs.
 
 # Preflight: fail fast if required baseline tools are missing (avoid sudo prompts/hangs).
-for bin in git jq rg tmux; do
-  command -v "" >/dev/null 2>&1 || { echo "ERROR: missing prerequisite: "; exit 3; }
-done
+command -v git  >/dev/null 2>&1 || { echo "ERROR: missing prerequisite: git"; exit 3; }
+command -v jq   >/dev/null 2>&1 || { echo "ERROR: missing prerequisite: jq"; exit 3; }
+command -v rg   >/dev/null 2>&1 || { echo "ERROR: missing prerequisite: rg"; exit 3; }
+command -v tmux >/dev/null 2>&1 || { echo "ERROR: missing prerequisite: tmux"; exit 3; }
 
 # If a host requires sudo for prereqs, the installer will fail fast.
 yes | bash "${REPO_DIR}/install.sh" --local "${REPO_DIR}" || { echo "ERROR: install.sh failed"; exit 5; }


### PR DESCRIPTION
Fixes Jenkinsfile.fleet-cli: preflight loop had been mangled into  causing immediate failures. Replace with explicit checks for git/jq/rg/tmux.