### PR TITLE
feat(dream): close bead + mark SHIPPED after SHIP verdict (eva-3s0)

### DIFF
--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -135,6 +135,8 @@ Before executing any task, workers self-refine their task prompt using `/refine`
    - Maximum re-review loop is exactly **2 loops** total per PR.
    - If an **architectural** issue is found, escalate immediately (**no fix attempt**) and record the escalation in the report.
    - If verdict is `SHIP`, mark the wish review-complete.
+     - Update wish file: set `**Status:** SHIPPED` in `.genie/wishes/<slug>/WISH.md` (replace existing Status line).
+     - Close bead: `bd close <slug>` (if bd unavailable or fails, log warning and continue — non-blocking).
 
 4. **Cleanup after review phase:**
    - Remove all per-wish worktrees:

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -19,6 +19,7 @@ Execute an approved wish from `.genie/wishes/<slug>/WISH.md`.
 7. **Mark complete:** update task state and wish checkboxes.
 8. **Repeat** until all groups are done.
 9. **Handoff:** `All work tasks complete. Run /review.`
+10. **Close:** set `**Status:** SHIPPED` in the wish file (replace existing Status line). Call `bd close <slug>` (if bd unavailable or fails, log warning and continue — non-blocking).
 
 ## Dispatch
 


### PR DESCRIPTION
## Summary\n- in dream review loop, after SHIP verdict, also update wish status to **Status:** SHIPPED\n- add bead closure command: \n- make bd failure explicitly non-blocking (log warning and continue)\n\n## Validation\n- ran:    - If verdict is `SHIP`, mark the wish review-complete.
     - Update wish file: set `**Status:** SHIPPED` in `.genie/wishes/<slug>/WISH.md` (replace existing Status line).
     - Close bead: `bd close <slug>` (if bd unavailable or fails, log warning and continue — non-blocking).

4. **Cleanup after review phase:**
   - Remove all per-wish worktrees:
     - `git worktree remove <worktree_path>`
   - Tear down the team context:
     - `TeamDelete`\n- confirmed new SHIPPED + bd close lines appear under SHIP verdict step\n