### PR TITLE
fix: beads install crash — wrong package name

### DIFF
--- a/plugins/automagik-genie/scripts/smart-install.js
+++ b/plugins/automagik-genie/scripts/smart-install.js
@@ -154,14 +154,14 @@ function isBeadsInstalled() {
 function installBeads() {
   console.error('Installing beads (bd)...');
   try {
-    execSync('npm install -g @anthropic-ai/bd', { stdio: 'inherit', shell: true });
+    execSync('npm install -g @beads/bd', { stdio: 'inherit', shell: true });
     if (!isBeadsInstalled()) {
       throw new Error('beads installation completed but bd not found.');
     }
     console.error('beads installed');
   } catch (error) {
     console.error('Failed to install beads. Please install manually:');
-    console.error('  npm install -g @anthropic-ai/bd');
+    console.error('  npm install -g @beads/bd');
     throw error;
   }
 }
@@ -280,7 +280,7 @@ function createCliSymlinks() {
 // Main execution
 try {
   // Quick check: if everything is already installed, exit silently
-  if (isBunInstalled() && isTmuxInstalled() && isBeadsInstalled() && !needsInstall() && symlinksExist()) {
+  if (isBunInstalled() && isTmuxInstalled() && !needsInstall() && symlinksExist()) {
     process.exit(0);
   }
 
@@ -310,9 +310,13 @@ try {
     process.exit(2); // Exit code 2 = blocking error for Claude to process
   }
 
-  // 3. Check/install beads
+  // 3. Check/install beads (optional — don't crash if unavailable)
   if (!isBeadsInstalled()) {
-    installBeads();
+    try {
+      installBeads();
+    } catch {
+      console.error('Warning: beads (bd) not available — skipping (optional dependency)');
+    }
   }
 
   // 4. Install dependencies if needed


### PR DESCRIPTION
## Summary
- Fixed wrong npm package name: `@anthropic-ai/bd` → `@beads/bd` (root cause of 404 crash)
- Removed `isBeadsInstalled()` from fast-path gate so missing beads doesn't block silent exit
- Wrapped beads install in try/catch so it warns instead of crashing the SessionStart hook

## Test plan
- [ ] Start a new Claude Code session — no `SessionStart:startup hook error`
- [ ] Second session hits fast path and exits silently (`process.exit(0)`)
- [ ] If `@beads/bd` is available on npm, it installs successfully on the slow path