### PR TITLE
feat: genie-cli-teams — provider-selectable orchestration

### DIFF
--- a/.genie/teams/debug.json
+++ b/.genie/teams/debug.json
@@ -1,0 +1,10 @@
+{
+  "name": "debug",
+  "blueprint": "debug",
+  "roles": [
+    { "name": "investigator", "description": "Investigates root causes" },
+    { "name": "reproducer", "description": "Creates minimal reproductions" }
+  ],
+  "createdAt": "2026-02-24T00:00:00.000Z",
+  "updatedAt": "2026-02-24T00:00:00.000Z"
+}

--- a/.genie/teams/dream.json
+++ b/.genie/teams/dream.json
@@ -1,0 +1,10 @@
+{
+  "name": "dream",
+  "blueprint": "dream",
+  "roles": [
+    { "name": "dreamer", "description": "Generates ideas and explores possibilities" },
+    { "name": "critic", "description": "Evaluates and refines ideas" }
+  ],
+  "createdAt": "2026-02-24T00:00:00.000Z",
+  "updatedAt": "2026-02-24T00:00:00.000Z"
+}

--- a/.genie/teams/fix.json
+++ b/.genie/teams/fix.json
@@ -1,0 +1,10 @@
+{
+  "name": "fix",
+  "blueprint": "fix",
+  "roles": [
+    { "name": "debugger", "description": "Diagnoses and fixes bugs" },
+    { "name": "verifier", "description": "Verifies fixes and writes regression tests" }
+  ],
+  "createdAt": "2026-02-24T00:00:00.000Z",
+  "updatedAt": "2026-02-24T00:00:00.000Z"
+}

--- a/.genie/teams/review.json
+++ b/.genie/teams/review.json
@@ -1,0 +1,10 @@
+{
+  "name": "review",
+  "blueprint": "review",
+  "roles": [
+    { "name": "reviewer", "description": "Deep code review" },
+    { "name": "security", "description": "Security-focused review" }
+  ],
+  "createdAt": "2026-02-24T00:00:00.000Z",
+  "updatedAt": "2026-02-24T00:00:00.000Z"
+}

--- a/.genie/teams/work.json
+++ b/.genie/teams/work.json
@@ -1,0 +1,11 @@
+{
+  "name": "work",
+  "blueprint": "work",
+  "roles": [
+    { "name": "implementor", "description": "Implements features and fixes bugs" },
+    { "name": "tester", "description": "Writes and runs tests" },
+    { "name": "reviewer", "description": "Reviews code and provides feedback" }
+  ],
+  "createdAt": "2026-02-24T00:00:00.000Z",
+  "updatedAt": "2026-02-24T00:00:00.000Z"
+}

--- a/.genie/wishes/genie-cli-teams/WISH.md
+++ b/.genie/wishes/genie-cli-teams/WISH.md
@@ -67,7 +67,7 @@ Build a `genie`-first orchestration stack (`team/task/worker/msg/term`) where Ge
 - [ ] Claude launches through public role routing (`--agent implementor`) with no hidden teammate flags
 - [ ] `genie worker spawn --provider codex --team work --skill work --role tester` launches worker and records provider metadata
 - [ ] Codex workers receive `$skill` instructions at spawn and do not depend on agent-name routing
-- [ ] Worker registry stores `provider`, `transport`, `session`, `window`, and `paneId`
+- [ ] Worker registry stores `provider`, `transport`, `session`, `window`, `paneId`, `role`, and `skill`
 - [ ] `genie msg send --to <worker>` writes mailbox entries and pushes delivery for both provider-backed workers
 - [ ] Default worker layout is mosaic/tiled; vertical layout only applies when explicitly requested
 - [ ] Invalid provider or invalid provider-specific argument combinations fail fast with actionable errors

--- a/.genie/wishes/genie-cli-teams/WISH.md
+++ b/.genie/wishes/genie-cli-teams/WISH.md
@@ -1,0 +1,263 @@
+# Wish: Genie CLI Teams — Provider-Selectable Genie Orchestration
+
+**Status:** DRAFT
+**Slug:** `genie-cli-teams`
+**Created:** 2026-02-24
+
+---
+
+## Problem
+
+Current orchestration can drift into provider-native coordination, but we need a Genie-owned orchestration core with explicit per-worker provider selection (`claude` or `codex`) over tmux.
+
+---
+
+## Summary
+
+Build a `genie`-first orchestration stack (`team/task/worker/msg/term`) where Genie owns mailbox, protocol routing, worker state, and task coupling. Worker launch is provider-selectable per worker with fixed adapters: Claude routes roles through `--agent`, and Codex loads `$skill` instructions for task behavior. Runtime transport stays tmux-only, with mosaic/tiled layout as the default for readability.
+
+---
+
+## Dependencies
+
+- **depends-on:** `none`
+- **blocks:** `none`
+
+---
+
+## Scope
+
+### IN
+- `genie` single-entry CLI namespaces: `team`, `task`, `worker`, `msg`, `term`
+- tmux-only worker runtime and pane orchestration
+- Per-worker provider selection: `genie worker spawn --provider <claude|codex>`
+- Fixed built-in provider adapters (no arbitrary shell adapter)
+- Claude adapter uses public CLI surface with `--agent <role>`
+- Codex adapter uses public CLI surface with `$skill` instructions as the task contract
+- Worker registry persists provider + transport metadata
+- Mailbox-first messaging and protocol routing owned by Genie
+- Default mosaic/tiled layout, optional vertical compatibility flag
+- New `genie-pilot` skill as canonical orchestration skill
+
+### OUT
+- Standalone `term` backward-compat alias/wrapper
+- Hidden/internal provider teammate flags as runtime dependencies
+- Provider-native orchestration ownership (Teams/Codex-native routing)
+- Non-tmux transports (`auto`, `in-process`, non-tmux backends)
+- Arbitrary user-defined shell command adapters for providers
+- Rewriting beads internals
+
+---
+
+## Decisions
+
+- **DEC-1:** Keep one entrypoint (`genie`), with `genie term` as namespaced low-level tmux operations. Rationale: no split command surface.
+- **DEC-2:** Provider is selected per worker (`--provider`) with fixed adapter implementations. Rationale: flexibility without unbounded adapter drift.
+- **DEC-3:** Claude adapter binds role-specific behavior using public `claude --agent <role>`. Rationale: explicit role routing without hidden internal flags.
+- **DEC-4:** Codex adapter binds behavior using `$skill` instructions at spawn; `--role` is advisory metadata only. Rationale: skill-driven contract fits Codex CLI surface.
+- **DEC-5:** Genie owns orchestration semantics (mailbox, protocol router, worker state, task coupling) independent of provider. Rationale: consistent behavior across providers.
+- **DEC-6:** tmux-only runtime with default mosaic/tiled layout (vertical opt-in). Rationale: deterministic transport and better human readability at higher worker counts.
+- **DEC-7:** Mailbox-first delivery with state-aware queueing before pane injection. Rationale: durability plus safer delivery under active output.
+
+---
+
+## Success Criteria
+
+- [ ] `genie worker spawn --provider claude --team work --role implementor` launches worker and records provider metadata
+- [ ] Claude launches through public role routing (`--agent implementor`) with no hidden teammate flags
+- [ ] `genie worker spawn --provider codex --team work --skill work --role tester` launches worker and records provider metadata
+- [ ] Codex workers receive `$skill` instructions at spawn and do not depend on agent-name routing
+- [ ] Worker registry stores `provider`, `transport`, `session`, `window`, and `paneId`
+- [ ] `genie msg send --to <worker>` writes mailbox entries and pushes delivery for both provider-backed workers
+- [ ] Default worker layout is mosaic/tiled; vertical layout only applies when explicitly requested
+- [ ] Invalid provider or invalid provider-specific argument combinations fail fast with actionable errors
+- [ ] `genie-pilot` skill exists and documents provider selection + Genie-owned orchestration boundary
+
+---
+
+## Assumptions
+
+- **ASM-1:** Claude environments expose a usable `--agent` path for configured agent roles.
+- **ASM-2:** Codex environments can reliably execute skill-driven instruction payloads for worker behavior.
+- **ASM-3:** tmux is available on target environments where orchestration runs.
+- **ASM-4:** Existing worker/task libraries are reusable with focused refactors.
+
+## Risks
+
+- **RISK-1:** Provider CLI flags/semantics evolve and break adapters. Mitigation: adapter tests + versioned launch builders.
+- **RISK-2:** Skill definition drift degrades Codex worker behavior. Mitigation: explicit skill contract in `genie-pilot` and validation checks.
+- **RISK-3:** Message injection can garble during active output. Mitigation: mailbox-first writes + state-aware queued delivery.
+- **RISK-4:** Operator confusion from per-worker provider differences. Mitigation: strict argument validation + clear dashboard metadata.
+
+---
+
+## Execution Groups
+
+### Group A: CLI Surface + Contract Validation
+
+**Goal:** Add explicit worker spawn contract for provider/role/skill selection under `genie`.
+
+**depends-on:** `none`  
+**blocks:** `B, C, D, E, F`
+
+**Deliverables:**
+- `genie worker spawn` accepts `--provider`, `--role`, and `--skill` (provider-aware validation rules)
+- Invalid combinations rejected (for example missing `--skill` for Codex path)
+- Updated CLI help for provider-aware worker commands
+
+**Acceptance Criteria:**
+- [ ] `genie worker spawn --help` documents provider/role/skill flags
+- [ ] Invalid provider values fail with actionable error
+- [ ] Invalid provider-specific argument combinations fail before spawn
+
+**Validation:** `genie worker spawn --help | rg -n 'provider|role|skill'`
+
+---
+
+### Group B: Team Model + Blueprint Defaults
+
+**Goal:** Keep team lifecycle and blueprints compatible with per-worker provider metadata.
+
+**depends-on:** `A`  
+**blocks:** `C, D, E, F`
+
+**Deliverables:**
+- Team CRUD stays intact under `genie team`
+- Blueprint schema supports role descriptors that can inform spawn defaults (without forcing team-level provider lock)
+- Team config persists role metadata used by worker spawn UX
+
+**Acceptance Criteria:**
+- [ ] `genie team create work-team --blueprint work` creates a valid team config
+- [ ] `genie team list` shows team presence and member/role info
+- [ ] `genie team delete work-team` succeeds when no workers are active
+
+**Validation:** `genie team create work-team --blueprint work && genie team list && genie team delete work-team`
+
+---
+
+### Group C: Provider Adapters (Claude + Codex)
+
+**Goal:** Implement fixed provider launch adapters with explicit role/skill contracts.
+
+**depends-on:** `A, B`  
+**blocks:** `D, E, F`
+
+**Deliverables:**
+- `src/lib/provider-adapters.ts` (or equivalent) with `claude` and `codex` launch builders
+- Claude adapter uses public CLI role routing (`--agent <role>`)
+- Codex adapter injects `$skill` instructions as task contract; role remains metadata
+- Preflight checks for provider binaries (`claude`, `codex`)
+- Unit tests for adapter command construction and invalid argument combinations
+
+**Acceptance Criteria:**
+- [ ] Claude adapter launch path includes `--agent <role>` and excludes hidden teammate flags
+- [ ] Codex adapter requires `--skill` and produces skill-driven launch payload
+- [ ] Preflight failures return actionable errors per provider
+
+**Validation:** `bun test src/lib/provider-adapters.test.ts`
+
+---
+
+### Group D: Tmux Worker Runtime + Layout
+
+**Goal:** Run provider-backed workers in tmux with stable lifecycle and readable default layout.
+
+**depends-on:** `A, B, C`  
+**blocks:** `E, F`
+
+**Deliverables:**
+- Worker spawn/list/kill/shutdown hooks wired through adapter output into tmux panes
+- Worker registry persists `provider`, `transport`, `session`, `window`, `paneId`, `role`, and `skill` metadata
+- Mosaic/tiled default layout with optional vertical compatibility flag
+- Spawn preflight errors for missing tmux/session constraints
+
+**Acceptance Criteria:**
+- [ ] Spawned workers from both providers appear in `genie worker list` with provider metadata
+- [ ] Default layout is mosaic/tiled without specifying a layout flag
+- [ ] Vertical layout activates only when explicitly requested
+- [ ] Shutdown removes pane and updates registry cleanly
+
+**Validation:** `genie worker list && jq '.workers[] | {provider,transport,session,window,paneId,role,skill}' ~/.config/genie/workers.json`
+
+---
+
+### Group E: Mailbox + Protocol Router
+
+**Goal:** Keep mailbox/protocol behavior consistent across provider-backed workers.
+
+**depends-on:** `A, B, C, D`  
+**blocks:** `F`
+
+**Deliverables:**
+- Durable mailbox store and unread/read semantics
+- Protocol router remains Genie-owned and provider-agnostic
+- State-aware queued delivery before tmux injection
+- Delivery receipts/visibility in worker message history
+
+**Acceptance Criteria:**
+- [ ] Messages persist to mailbox before push delivery for all providers
+- [ ] Mid-turn workers receive queued delivery when idle
+- [ ] `genie msg inbox <worker>` reflects accurate message history
+
+**Validation:** `genie msg send --to implementor 'ping' && genie msg inbox implementor`
+
+---
+
+### Group F: Integration + Genie Pilot Skill
+
+**Goal:** Ship cohesive orchestration UX with task integration and skill docs.
+
+**depends-on:** `A, B, C, D, E`  
+**blocks:** `none`
+
+**Deliverables:**
+- `genie task` integration remains dependency-aware (`ready` vs `blocked`)
+- Unified worker dashboard includes provider metadata and message/task visibility
+- Create `skills/genie-pilot/SKILL.md` as canonical orchestration skill
+- Document provider contract:
+  - Claude uses `--agent <role>`
+  - Codex uses `$skill` task instructions
+  - Genie owns orchestration state/protocol
+
+**Acceptance Criteria:**
+- [ ] `genie task list` differentiates ready and blocked tasks
+- [ ] Dashboard surfaces provider + worker state + task + message context
+- [ ] `skills/genie-pilot/SKILL.md` documents provider contracts and boundaries
+
+**Validation:** `genie task list && genie worker dashboard && test -f skills/genie-pilot/SKILL.md`
+
+---
+
+## Review Results
+
+_Populated by `/review` after execution completes._
+
+---
+
+## Files to Create/Modify
+
+```text
+# New files
+src/genie.ts
+src/lib/provider-adapters.ts
+src/lib/mosaic-layout.ts
+src/lib/mailbox.ts
+src/lib/protocol-router.ts
+src/lib/team-manager.ts
+src/lib/provider-adapters.test.ts
+.genie/teams/work.json
+.genie/teams/dream.json
+.genie/teams/review.json
+.genie/teams/fix.json
+.genie/teams/debug.json
+skills/genie-pilot/SKILL.md
+
+# Modified files
+src/term.ts
+src/lib/worker-registry.ts
+src/term-commands/work.ts
+src/term-commands/workers.ts
+src/term-commands/orchestrate.ts
+src/term-commands/task/commands.ts
+package.json
+```

--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ yarn-error.log*
 .genie/tasks.json
 .genie/state.json
 
-# Lock files
-bun.lock
-
 # bd worktree (legacy)
 genie-cli-e6q/
 genie-cli-z84/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 dist/
 build/
 *.js.map
+*.tsbuildinfo
 
 # Plugin package.json (generated)
 plugin/package.json
@@ -46,6 +47,14 @@ yarn-error.log*
 
 # Worker registry (contains session IDs)
 .genie/workers.json
+
+# Team runtime state
+.genie/mailbox/
+.genie/tasks.json
+.genie/state.json
+
+# Lock files
+bun.lock
 
 # bd worktree (legacy)
 genie-cli-e6q/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "build:plugin": "node scripts/build.js",
     "sync": "node scripts/sync.js",
     "build-and-sync": "npm run build:plugin && npm run sync",
-    "prepack": "bun run build"
+    "prepack": "bun run build",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",

--- a/skills/genie-pilot/SKILL.md
+++ b/skills/genie-pilot/SKILL.md
@@ -1,0 +1,85 @@
+# Skill: genie-pilot
+
+Canonical orchestration skill for Genie CLI teams.
+
+## Purpose
+
+You are a Genie Pilot — the orchestration driver that manages
+multi-worker teams across providers. You own the coordination
+loop: spawn workers, route messages, track tasks, and maintain
+team state.
+
+## Provider Contracts
+
+### Claude Workers
+- Launched via: `claude --agent <role>`
+- Role routing uses the public `--agent` flag (no hidden teammate flags)
+- Worker behavior is determined by the agent role configuration
+- Example: `genie worker spawn --provider claude --team work --role implementor`
+
+### Codex Workers
+- Launched via: `codex --instructions <skill-instructions>`
+- Worker behavior comes from explicit skill instructions injected at spawn
+- `--role` is advisory metadata only (for registry/visibility, not routing)
+- Example: `genie worker spawn --provider codex --team work --skill work --role tester`
+
+## Genie-Owned Orchestration Boundary
+
+Genie owns these semantics regardless of provider:
+
+| Layer | Owner | Description |
+|-------|-------|-------------|
+| Mailbox | Genie | Durable message persistence before delivery |
+| Protocol Router | Genie | Provider-agnostic message routing |
+| Worker State | Genie | Lifecycle tracking (spawning/working/idle/done) |
+| Task Coupling | Genie | Dependency-aware task assignment to workers |
+| Delivery | Genie | State-aware queued delivery to tmux panes |
+
+Providers only launch worker processes. They do not own coordination.
+
+## Commands Quick Reference
+
+```bash
+# Team management
+genie team create work-team --blueprint work
+genie team list
+genie team delete work-team
+
+# Worker lifecycle
+genie worker spawn --provider claude --team work --role implementor
+genie worker spawn --provider codex --team work --skill work --role tester
+genie worker list
+genie worker kill <id>
+genie worker dashboard
+
+# Messaging (mailbox-first)
+genie msg send --to <worker> 'message body'
+genie msg inbox <worker>
+
+# Tasks (dependency-aware)
+genie task create "implement feature X"
+genie task list
+genie task update <id> --status done
+```
+
+## Layout
+
+Default layout is **mosaic/tiled** for readability at higher worker
+counts. Vertical layout is available only when explicitly requested
+via `--layout vertical`.
+
+## Orchestration Loop
+
+1. Create a team from a blueprint
+2. Spawn workers with provider selection
+3. Assign tasks to workers
+4. Monitor via dashboard
+5. Route messages between workers via mailbox
+6. Track task completion and dependencies
+7. Shutdown workers when done
+
+## Non-Goals
+
+- Genie Pilot does not replace provider-native orchestration
+- Genie Pilot does not manage non-tmux transports
+- Genie Pilot does not provide arbitrary shell command adapters

--- a/src/genie.ts
+++ b/src/genie.ts
@@ -1,5 +1,13 @@
 #!/usr/bin/env bun
 
+/**
+ * genie — Single entrypoint CLI with namespaces:
+ *   team, task, worker, msg, term
+ *
+ * DEC-1: One entrypoint (`genie`), with `genie term` as namespaced
+ * low-level tmux operations. No split command surface.
+ */
+
 import { Command } from 'commander';
 import { VERSION } from './lib/version.js';
 import { installCommand } from './genie-commands/install.js';
@@ -28,6 +36,13 @@ import {
 } from './genie-commands/pdf.js';
 import { brainstormCrystallizeCommand } from './genie-commands/brainstorm/crystallize.js';
 import { ledgerValidateCommand } from './genie-commands/ledger/validate.js';
+
+// Provider-selectable orchestration namespaces (genie-cli-teams)
+import { registerTeamNamespace } from './term-commands/team.js';
+import { registerWorkerNamespace } from './term-commands/workers.js';
+import { registerMsgNamespace } from './term-commands/msg.js';
+import { registerTaskNamespace } from './term-commands/task/commands.js';
+import { registerTermNamespace } from './term-commands/term.js';
 
 const program = new Command();
 
@@ -201,5 +216,15 @@ ledger
   .option('-r, --repo <path>', 'Repo path (default: cwd)')
   .option('--json', 'Output JSON')
   .action(ledgerValidateCommand);
+
+// ============================================================================
+// Provider-selectable orchestration namespaces (genie-cli-teams)
+// ============================================================================
+
+registerTeamNamespace(program);
+registerWorkerNamespace(program);
+registerMsgNamespace(program);
+registerTaskNamespace(program);
+registerTermNamespace(program);
 
 program.parse();

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -9,7 +9,8 @@
  */
 
 import { mkdir, readFile, writeFile } from 'fs/promises';
-import { join } from 'path';
+import path, { join } from 'path';
+import { v4 as uuidv4 } from 'uuid';
 
 // ============================================================================
 // Types
@@ -47,7 +48,8 @@ function mailboxDir(repoPath: string): string {
 }
 
 function mailboxFilePath(repoPath: string, workerId: string): string {
-  return join(mailboxDir(repoPath), `${workerId}.json`);
+  const safeId = path.basename(workerId);
+  return join(mailboxDir(repoPath), `${safeId}.json`);
 }
 
 // ============================================================================
@@ -77,11 +79,8 @@ async function saveMailbox(repoPath: string, mailbox: WorkerMailbox): Promise<vo
 // Public API
 // ============================================================================
 
-let _messageCounter = 0;
-
 function generateMessageId(): string {
-  _messageCounter += 1;
-  return `msg-${Date.now()}-${_messageCounter}`;
+  return `msg-${uuidv4()}`;
 }
 
 /**

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -1,0 +1,179 @@
+/**
+ * Mailbox — Durable message store with unread/read semantics.
+ *
+ * Messages persist to `.genie/mailbox/<worker-id>.json` before
+ * any push delivery attempt. This ensures durability (DEC-7).
+ *
+ * Delivery is state-aware: messages are queued and pushed to tmux
+ * panes only when the worker is idle (not mid-turn).
+ */
+
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface MailboxMessage {
+  /** Unique message ID. */
+  id: string;
+  /** Sender worker ID or "operator" for human-initiated messages. */
+  from: string;
+  /** Recipient worker ID. */
+  to: string;
+  /** Message body text. */
+  body: string;
+  /** ISO timestamp when message was created. */
+  createdAt: string;
+  /** Whether the recipient has read this message. */
+  read: boolean;
+  /** ISO timestamp when message was delivered to pane (null if pending). */
+  deliveredAt: string | null;
+}
+
+export interface WorkerMailbox {
+  workerId: string;
+  messages: MailboxMessage[];
+  lastUpdated: string;
+}
+
+// ============================================================================
+// Paths
+// ============================================================================
+
+function mailboxDir(repoPath: string): string {
+  return join(repoPath, '.genie', 'mailbox');
+}
+
+function mailboxFilePath(repoPath: string, workerId: string): string {
+  return join(mailboxDir(repoPath), `${workerId}.json`);
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+async function loadMailbox(repoPath: string, workerId: string): Promise<WorkerMailbox> {
+  try {
+    const content = await readFile(mailboxFilePath(repoPath, workerId), 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return { workerId, messages: [], lastUpdated: new Date().toISOString() };
+  }
+}
+
+async function saveMailbox(repoPath: string, mailbox: WorkerMailbox): Promise<void> {
+  const dir = mailboxDir(repoPath);
+  await mkdir(dir, { recursive: true });
+  mailbox.lastUpdated = new Date().toISOString();
+  await writeFile(
+    mailboxFilePath(repoPath, mailbox.workerId),
+    JSON.stringify(mailbox, null, 2),
+  );
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+let _messageCounter = 0;
+
+function generateMessageId(): string {
+  _messageCounter += 1;
+  return `msg-${Date.now()}-${_messageCounter}`;
+}
+
+/**
+ * Write a message to a worker's mailbox.
+ * This persists BEFORE any delivery attempt (DEC-7).
+ */
+export async function send(
+  repoPath: string,
+  from: string,
+  to: string,
+  body: string,
+): Promise<MailboxMessage> {
+  const mailbox = await loadMailbox(repoPath, to);
+
+  const message: MailboxMessage = {
+    id: generateMessageId(),
+    from,
+    to,
+    body,
+    createdAt: new Date().toISOString(),
+    read: false,
+    deliveredAt: null,
+  };
+
+  mailbox.messages.push(message);
+  await saveMailbox(repoPath, mailbox);
+
+  return message;
+}
+
+/**
+ * Get all messages for a worker (inbox view).
+ */
+export async function inbox(
+  repoPath: string,
+  workerId: string,
+): Promise<MailboxMessage[]> {
+  const mailbox = await loadMailbox(repoPath, workerId);
+  return mailbox.messages;
+}
+
+/**
+ * Get unread messages for a worker.
+ */
+export async function unread(
+  repoPath: string,
+  workerId: string,
+): Promise<MailboxMessage[]> {
+  const mailbox = await loadMailbox(repoPath, workerId);
+  return mailbox.messages.filter(m => !m.read);
+}
+
+/**
+ * Mark a message as read.
+ */
+export async function markRead(
+  repoPath: string,
+  workerId: string,
+  messageId: string,
+): Promise<boolean> {
+  const mailbox = await loadMailbox(repoPath, workerId);
+  const msg = mailbox.messages.find(m => m.id === messageId);
+  if (!msg) return false;
+  msg.read = true;
+  await saveMailbox(repoPath, mailbox);
+  return true;
+}
+
+/**
+ * Mark a message as delivered (pane injection succeeded).
+ */
+export async function markDelivered(
+  repoPath: string,
+  workerId: string,
+  messageId: string,
+): Promise<boolean> {
+  const mailbox = await loadMailbox(repoPath, workerId);
+  const msg = mailbox.messages.find(m => m.id === messageId);
+  if (!msg) return false;
+  msg.deliveredAt = new Date().toISOString();
+  await saveMailbox(repoPath, mailbox);
+  return true;
+}
+
+/**
+ * Get pending (undelivered) messages for a worker.
+ * Used by the delivery loop to push queued messages.
+ */
+export async function pending(
+  repoPath: string,
+  workerId: string,
+): Promise<MailboxMessage[]> {
+  const mailbox = await loadMailbox(repoPath, workerId);
+  return mailbox.messages.filter(m => m.deliveredAt === null);
+}

--- a/src/lib/mosaic-layout.ts
+++ b/src/lib/mosaic-layout.ts
@@ -1,0 +1,44 @@
+/**
+ * Mosaic Layout — Default tiled layout for tmux worker panes.
+ *
+ * Provides mosaic/tiled layout as the default (DEC-6), with vertical
+ * layout available only when explicitly requested.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type LayoutMode = 'mosaic' | 'vertical';
+
+// ============================================================================
+// Layout Application
+// ============================================================================
+
+/**
+ * Build a tmux command to apply the desired layout to a window.
+ *
+ * - "mosaic" → `select-layout tiled` (default, DEC-6)
+ * - "vertical" → `select-layout even-horizontal`
+ *
+ * @param windowTarget — tmux window target (e.g., "session:0" or "@4")
+ * @param mode — Layout mode. Defaults to "mosaic".
+ */
+export function buildLayoutCommand(
+  windowTarget: string,
+  mode: LayoutMode = 'mosaic',
+): string {
+  const layout = mode === 'vertical' ? 'even-horizontal' : 'tiled';
+  return `select-layout -t '${windowTarget}' ${layout}`;
+}
+
+/**
+ * Determine the layout mode from CLI flags.
+ *
+ * If `--layout vertical` is specified, use vertical.
+ * Otherwise default to mosaic (DEC-6).
+ */
+export function resolveLayoutMode(layoutFlag?: string): LayoutMode {
+  if (layoutFlag === 'vertical') return 'vertical';
+  return 'mosaic';
+}

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -46,9 +46,20 @@ export async function sendMessage(
   if (!worker) {
     // Try finding by fuzzy match (team:role pattern)
     const allWorkers = await registry.list();
-    const match = allWorkers.find(w =>
+    const matches = allWorkers.filter(w =>
       w.id === to || w.role === to || `${w.team}:${w.role}` === to
     );
+
+    if (matches.length > 1) {
+      return {
+        messageId: '',
+        workerId: to,
+        delivered: false,
+        reason: `Worker "${to}" is ambiguous. Found ${matches.length} matches: ${matches.map(m => m.id).join(', ')}. Please use a unique worker ID.`,
+      };
+    }
+
+    const match = matches[0];
 
     if (!match) {
       return {

--- a/src/lib/protocol-router.ts
+++ b/src/lib/protocol-router.ts
@@ -1,0 +1,127 @@
+/**
+ * Protocol Router — Genie-owned message routing across providers.
+ *
+ * The protocol router is provider-agnostic (DEC-5). It routes
+ * messages between workers regardless of whether they are backed
+ * by Claude or Codex. Delivery goes through the mailbox first
+ * (DEC-7) and then pushes to the tmux pane when the worker is idle.
+ */
+
+import * as mailbox from './mailbox.js';
+import * as registry from './worker-registry.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DeliveryResult {
+  messageId: string;
+  workerId: string;
+  delivered: boolean;
+  reason?: string;
+}
+
+// ============================================================================
+// Delivery
+// ============================================================================
+
+/**
+ * Send a message to a worker. The message is persisted to the
+ * mailbox BEFORE any delivery attempt.
+ *
+ * @param repoPath — Repository root path for mailbox storage.
+ * @param from — Sender ID ("operator" for human messages).
+ * @param to — Recipient worker ID.
+ * @param body — Message body text.
+ * @returns Delivery result with message ID.
+ */
+export async function sendMessage(
+  repoPath: string,
+  from: string,
+  to: string,
+  body: string,
+): Promise<DeliveryResult> {
+  // 1. Verify recipient exists in registry
+  const worker = await registry.get(to);
+  if (!worker) {
+    // Try finding by fuzzy match (team:role pattern)
+    const allWorkers = await registry.list();
+    const match = allWorkers.find(w =>
+      w.id === to || w.role === to || `${w.team}:${w.role}` === to
+    );
+
+    if (!match) {
+      return {
+        messageId: '',
+        workerId: to,
+        delivered: false,
+        reason: `Worker "${to}" not found in registry`,
+      };
+    }
+
+    // Use the matched worker
+    const message = await mailbox.send(repoPath, from, match.id, body);
+    return {
+      messageId: message.id,
+      workerId: match.id,
+      delivered: true,
+    };
+  }
+
+  // 2. Persist to mailbox first (DEC-7)
+  const message = await mailbox.send(repoPath, from, to, body);
+
+  return {
+    messageId: message.id,
+    workerId: to,
+    delivered: true,
+  };
+}
+
+/**
+ * Attempt to push pending messages to a worker's tmux pane.
+ * Called when a worker transitions to idle state.
+ *
+ * This is a no-op placeholder — actual tmux injection would require
+ * the tmux library. The delivery attempt is recorded in the mailbox.
+ */
+export async function flushPending(
+  repoPath: string,
+  workerId: string,
+): Promise<DeliveryResult[]> {
+  const messages = await mailbox.pending(repoPath, workerId);
+  const results: DeliveryResult[] = [];
+
+  for (const msg of messages) {
+    // Mark as delivered (actual tmux injection would happen here)
+    await mailbox.markDelivered(repoPath, workerId, msg.id);
+    results.push({
+      messageId: msg.id,
+      workerId,
+      delivered: true,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Get the inbox for a worker (all messages, with read/unread status).
+ */
+export async function getInbox(
+  repoPath: string,
+  workerId: string,
+): Promise<mailbox.MailboxMessage[]> {
+  return mailbox.inbox(repoPath, workerId);
+}
+
+/**
+ * Get unread message count for a worker.
+ */
+export async function unreadCount(
+  repoPath: string,
+  workerId: string,
+): Promise<number> {
+  const messages = await mailbox.unread(repoPath, workerId);
+  return messages.length;
+}

--- a/src/lib/provider-adapters.test.ts
+++ b/src/lib/provider-adapters.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Provider Adapters — Unit Tests
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  buildLaunchCommand,
+  buildClaudeCommand,
+  buildCodexCommand,
+  validateSpawnParams,
+  type SpawnParams,
+} from './provider-adapters.js';
+
+// ============================================================================
+// Validation Tests (Group A)
+// ============================================================================
+
+describe('validateSpawnParams', () => {
+  it('accepts valid claude params', () => {
+    const params: SpawnParams = { provider: 'claude', team: 'work', role: 'implementor' };
+    const result = validateSpawnParams(params);
+    expect(result.provider).toBe('claude');
+    expect(result.team).toBe('work');
+    expect(result.role).toBe('implementor');
+  });
+
+  it('accepts valid codex params with skill', () => {
+    const params: SpawnParams = { provider: 'codex', team: 'work', skill: 'work', role: 'tester' };
+    const result = validateSpawnParams(params);
+    expect(result.provider).toBe('codex');
+    expect(result.skill).toBe('work');
+  });
+
+  it('rejects invalid provider', () => {
+    expect(() => validateSpawnParams({ provider: 'gpt' as any, team: 'work' })).toThrow();
+  });
+
+  it('rejects empty team', () => {
+    expect(() => validateSpawnParams({ provider: 'claude', team: '' })).toThrow();
+  });
+
+  it('rejects codex without skill', () => {
+    expect(() => validateSpawnParams({ provider: 'codex', team: 'work' })).toThrow(
+      /Codex provider requires --skill/
+    );
+  });
+
+  it('allows claude without skill', () => {
+    const params: SpawnParams = { provider: 'claude', team: 'work' };
+    const result = validateSpawnParams(params);
+    expect(result.provider).toBe('claude');
+  });
+});
+
+// ============================================================================
+// Claude Adapter Tests (Group C)
+// ============================================================================
+
+describe('buildClaudeCommand', () => {
+  it('builds command with --agent role', () => {
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'implementor' });
+    expect(result.command).toContain('claude');
+    expect(result.command).toContain('--agent');
+    expect(result.command).toContain('implementor');
+    expect(result.provider).toBe('claude');
+    expect(result.meta.role).toBe('implementor');
+  });
+
+  it('excludes --agent when no role specified', () => {
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work' });
+    expect(result.command).toBe('claude');
+    expect(result.command).not.toContain('--agent');
+  });
+
+  it('does not include hidden teammate flags', () => {
+    const result = buildClaudeCommand({ provider: 'claude', team: 'work', role: 'implementor' });
+    expect(result.command).not.toContain('--teammate');
+    expect(result.command).not.toContain('--internal');
+  });
+
+  it('forwards extra args', () => {
+    const result = buildClaudeCommand({
+      provider: 'claude',
+      team: 'work',
+      role: 'implementor',
+      extraArgs: ['--dangerously-skip-permissions'],
+    });
+    expect(result.command).toContain('--dangerously-skip-permissions');
+  });
+});
+
+// ============================================================================
+// Codex Adapter Tests (Group C)
+// ============================================================================
+
+describe('buildCodexCommand', () => {
+  it('builds command with --instructions for skill', () => {
+    const result = buildCodexCommand({ provider: 'codex', team: 'work', skill: 'work', role: 'tester' });
+    expect(result.command).toContain('codex');
+    expect(result.command).toContain('--instructions');
+    expect(result.command).toContain('work');
+    expect(result.provider).toBe('codex');
+    expect(result.meta.skill).toBe('work');
+    expect(result.meta.role).toBe('tester');
+  });
+
+  it('throws when skill is missing', () => {
+    expect(() => buildCodexCommand({ provider: 'codex', team: 'work' })).toThrow(/requires --skill/);
+  });
+
+  it('includes role as advisory metadata in instructions', () => {
+    const result = buildCodexCommand({ provider: 'codex', team: 'work', skill: 'work', role: 'tester' });
+    expect(result.command).toContain('Role: tester');
+    expect(result.command).toContain('advisory');
+  });
+
+  it('does not depend on agent-name routing', () => {
+    const result = buildCodexCommand({ provider: 'codex', team: 'work', skill: 'work' });
+    expect(result.command).not.toContain('--agent');
+  });
+
+  it('forwards extra args', () => {
+    const result = buildCodexCommand({
+      provider: 'codex',
+      team: 'work',
+      skill: 'work',
+      extraArgs: ['--model', 'o3'],
+    });
+    expect(result.command).toContain('--model');
+    expect(result.command).toContain('o3');
+  });
+});
+
+// ============================================================================
+// Dispatch Tests (Group C)
+// ============================================================================
+
+describe('buildLaunchCommand', () => {
+  it('dispatches to claude adapter', () => {
+    const result = buildLaunchCommand({ provider: 'claude', team: 'work', role: 'implementor' });
+    expect(result.provider).toBe('claude');
+    expect(result.command).toContain('claude');
+  });
+
+  it('dispatches to codex adapter', () => {
+    const result = buildLaunchCommand({ provider: 'codex', team: 'work', skill: 'work' });
+    expect(result.provider).toBe('codex');
+    expect(result.command).toContain('codex');
+  });
+
+  it('rejects invalid provider before dispatch', () => {
+    expect(() => buildLaunchCommand({ provider: 'invalid' as any, team: 'work' })).toThrow();
+  });
+
+  it('rejects codex without skill at dispatch', () => {
+    expect(() => buildLaunchCommand({ provider: 'codex', team: 'work' })).toThrow(/--skill/);
+  });
+});

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -1,0 +1,220 @@
+/**
+ * Provider Adapters — Fixed launch builders for Claude and Codex.
+ *
+ * Each adapter translates Genie worker-spawn options into the
+ * provider-specific CLI invocation that tmux will execute.
+ *
+ * - Claude adapter: `claude --agent <role> [flags]`
+ * - Codex adapter:  `codex --instructions <skill-instructions> [flags]`
+ *
+ * Genie owns all orchestration semantics (mailbox, protocol, worker
+ * state, task coupling). The provider merely launches the process.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ProviderName = 'claude' | 'codex';
+
+/** Common spawn parameters accepted by both providers. */
+export interface SpawnParams {
+  provider: ProviderName;
+  team: string;
+  role?: string;
+  skill?: string;
+  /** Extra CLI flags forwarded verbatim to the provider binary. */
+  extraArgs?: string[];
+}
+
+/** Result of a successful launch-command build. */
+export interface LaunchCommand {
+  /** The full shell command string. */
+  command: string;
+  /** The provider that was used. */
+  provider: ProviderName;
+  /** Metadata recorded in the worker registry. */
+  meta: {
+    role?: string;
+    skill?: string;
+  };
+}
+
+// ============================================================================
+// Validation schemas (Group A contract validation)
+// ============================================================================
+
+export const spawnParamsSchema = z.object({
+  provider: z.enum(['claude', 'codex']),
+  team: z.string().min(1, 'Team name is required'),
+  role: z.string().optional(),
+  skill: z.string().optional(),
+  extraArgs: z.array(z.string()).optional(),
+});
+
+/**
+ * Validate spawn parameters and return actionable errors.
+ * Throws ZodError on invalid input.
+ */
+export function validateSpawnParams(params: SpawnParams): SpawnParams {
+  const parsed = spawnParamsSchema.parse(params);
+
+  // Provider-specific validation rules
+  if (parsed.provider === 'codex' && !parsed.skill) {
+    throw new Error(
+      'Codex provider requires --skill. ' +
+      'Example: genie worker spawn --provider codex --team work --skill work --role tester'
+    );
+  }
+
+  return parsed as SpawnParams;
+}
+
+// ============================================================================
+// Shell Helpers
+// ============================================================================
+
+function escapeShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+// ============================================================================
+// Preflight Checks
+// ============================================================================
+
+/**
+ * Check if a binary exists on PATH.
+ * Returns true if found, false otherwise.
+ */
+export function hasBinary(name: string): boolean {
+  try {
+    // @ts-ignore — Bun.which is available at runtime
+    if (typeof (Bun as any).which === 'function') {
+      return Boolean((Bun as any).which(name));
+    }
+  } catch {
+    // fallback: assume available
+  }
+  return true;
+}
+
+/**
+ * Run preflight checks for a provider.
+ * Throws with an actionable error if the binary is not found.
+ */
+export function preflightCheck(provider: ProviderName): void {
+  if (!hasBinary(provider)) {
+    throw new Error(
+      `Provider binary "${provider}" not found on PATH. ` +
+      `Install ${provider} or check your environment.`
+    );
+  }
+}
+
+// ============================================================================
+// Claude Adapter
+// ============================================================================
+
+/**
+ * Build the launch command for a Claude worker.
+ *
+ * Uses `claude --agent <role>` for role-specific behavior.
+ * No hidden teammate flags — public CLI surface only.
+ */
+export function buildClaudeCommand(params: SpawnParams): LaunchCommand {
+  preflightCheck('claude');
+
+  const parts: string[] = ['claude'];
+
+  // Role routing via --agent (DEC-3)
+  if (params.role) {
+    parts.push('--agent', escapeShellArg(params.role));
+  }
+
+  // Forward extra args
+  if (params.extraArgs) {
+    for (const arg of params.extraArgs) {
+      parts.push(escapeShellArg(arg));
+    }
+  }
+
+  return {
+    command: parts.join(' '),
+    provider: 'claude',
+    meta: {
+      role: params.role,
+      skill: params.skill,
+    },
+  };
+}
+
+// ============================================================================
+// Codex Adapter
+// ============================================================================
+
+/**
+ * Build the launch command for a Codex worker.
+ *
+ * Uses `codex` with `--instructions` to inject skill-based task
+ * instructions. Role is advisory metadata only (DEC-4).
+ */
+export function buildCodexCommand(params: SpawnParams): LaunchCommand {
+  preflightCheck('codex');
+
+  if (!params.skill) {
+    throw new Error(
+      'Codex adapter requires --skill. ' +
+      'The skill provides task instructions for the worker.'
+    );
+  }
+
+  const parts: string[] = ['codex'];
+
+  // Skill-driven instructions (DEC-4)
+  const instructions = `Genie worker. Team: ${params.team}. Skill: ${params.skill}.${params.role ? ` Role: ${params.role} (advisory).` : ''} Execute the ${params.skill} skill instructions.`;
+  parts.push('--instructions', escapeShellArg(instructions));
+
+  // Forward extra args
+  if (params.extraArgs) {
+    for (const arg of params.extraArgs) {
+      parts.push(escapeShellArg(arg));
+    }
+  }
+
+  return {
+    command: parts.join(' '),
+    provider: 'codex',
+    meta: {
+      role: params.role,
+      skill: params.skill,
+    },
+  };
+}
+
+// ============================================================================
+// Dispatch
+// ============================================================================
+
+/**
+ * Build a launch command for the given provider.
+ *
+ * This is the main entry point. It validates params, runs preflight
+ * checks, and delegates to the appropriate adapter.
+ */
+export function buildLaunchCommand(params: SpawnParams): LaunchCommand {
+  const validated = validateSpawnParams(params);
+
+  switch (validated.provider) {
+    case 'claude':
+      return buildClaudeCommand(validated);
+    case 'codex':
+      return buildCodexCommand(validated);
+    default:
+      throw new Error(
+        `Unknown provider "${(validated as any).provider}". ` +
+        'Valid providers: claude, codex'
+      );
+  }
+}

--- a/src/lib/provider-adapters.ts
+++ b/src/lib/provider-adapters.ts
@@ -94,10 +94,12 @@ export function hasBinary(name: string): boolean {
     if (typeof (Bun as any).which === 'function') {
       return Boolean((Bun as any).which(name));
     }
+    const { execSync } = require('child_process');
+    execSync(`which ${name}`, { stdio: 'ignore' });
+    return true;
   } catch {
-    // fallback: assume available
+    return false;
   }
-  return true;
 }
 
 /**

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -1,0 +1,192 @@
+/**
+ * Team Manager — CRUD for team lifecycle and blueprint defaults.
+ *
+ * Teams are stored as JSON files in `.genie/teams/<name>.json`.
+ * Blueprints provide role descriptors that inform spawn defaults
+ * without forcing a team-level provider lock (DEC-2).
+ */
+
+import { mkdir, readFile, writeFile, readdir, unlink } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import type { ProviderName } from './provider-adapters.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Role descriptor within a team blueprint. */
+export interface RoleDescriptor {
+  /** Human-readable role name (e.g., "implementor", "tester"). */
+  name: string;
+  /** Suggested provider for this role (optional — not enforced). */
+  suggestedProvider?: ProviderName;
+  /** Suggested skill for codex workers in this role. */
+  suggestedSkill?: string;
+  /** Free-form description of what this role does. */
+  description?: string;
+}
+
+/** Blueprint schema — provides default role descriptors for a team type. */
+export interface Blueprint {
+  name: string;
+  roles: RoleDescriptor[];
+}
+
+/** Persisted team configuration. */
+export interface TeamConfig {
+  /** Team name (unique identifier). */
+  name: string;
+  /** Blueprint that was used to create the team (informational). */
+  blueprint?: string;
+  /** Role descriptors (may be customized from blueprint defaults). */
+  roles: RoleDescriptor[];
+  /** ISO timestamp of creation. */
+  createdAt: string;
+  /** ISO timestamp of last update. */
+  updatedAt: string;
+}
+
+// ============================================================================
+// Built-in Blueprints
+// ============================================================================
+
+const BLUEPRINTS: Record<string, Blueprint> = {
+  work: {
+    name: 'work',
+    roles: [
+      { name: 'implementor', description: 'Implements features and fixes bugs' },
+      { name: 'tester', description: 'Writes and runs tests' },
+      { name: 'reviewer', description: 'Reviews code and provides feedback' },
+    ],
+  },
+  dream: {
+    name: 'dream',
+    roles: [
+      { name: 'dreamer', description: 'Generates ideas and explores possibilities' },
+      { name: 'critic', description: 'Evaluates and refines ideas' },
+    ],
+  },
+  review: {
+    name: 'review',
+    roles: [
+      { name: 'reviewer', description: 'Deep code review' },
+      { name: 'security', description: 'Security-focused review' },
+    ],
+  },
+  fix: {
+    name: 'fix',
+    roles: [
+      { name: 'debugger', description: 'Diagnoses and fixes bugs' },
+      { name: 'verifier', description: 'Verifies fixes and writes regression tests' },
+    ],
+  },
+  debug: {
+    name: 'debug',
+    roles: [
+      { name: 'investigator', description: 'Investigates root causes' },
+      { name: 'reproducer', description: 'Creates minimal reproductions' },
+    ],
+  },
+};
+
+// ============================================================================
+// Paths
+// ============================================================================
+
+function teamsDir(repoPath: string): string {
+  return join(repoPath, '.genie', 'teams');
+}
+
+function teamFilePath(repoPath: string, name: string): string {
+  return join(teamsDir(repoPath), `${name}.json`);
+}
+
+// ============================================================================
+// API
+// ============================================================================
+
+/** Get a blueprint by name. Returns null if not found. */
+export function getBlueprint(name: string): Blueprint | null {
+  return BLUEPRINTS[name] ?? null;
+}
+
+/** List all available blueprint names. */
+export function listBlueprints(): string[] {
+  return Object.keys(BLUEPRINTS);
+}
+
+/** Create a new team from a blueprint. */
+export async function createTeam(
+  repoPath: string,
+  name: string,
+  blueprintName?: string,
+): Promise<TeamConfig> {
+  const dir = teamsDir(repoPath);
+  await mkdir(dir, { recursive: true });
+
+  const filePath = teamFilePath(repoPath, name);
+  if (existsSync(filePath)) {
+    throw new Error(`Team "${name}" already exists. Delete it first or choose a different name.`);
+  }
+
+  const blueprint = blueprintName ? getBlueprint(blueprintName) : null;
+  if (blueprintName && !blueprint) {
+    const available = listBlueprints().join(', ');
+    throw new Error(`Blueprint "${blueprintName}" not found. Available: ${available}`);
+  }
+
+  const now = new Date().toISOString();
+  const config: TeamConfig = {
+    name,
+    blueprint: blueprintName,
+    roles: blueprint?.roles ?? [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await writeFile(filePath, JSON.stringify(config, null, 2));
+  return config;
+}
+
+/** Get a team by name. Returns null if not found. */
+export async function getTeam(repoPath: string, name: string): Promise<TeamConfig | null> {
+  try {
+    const content = await readFile(teamFilePath(repoPath, name), 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/** List all teams. */
+export async function listTeams(repoPath: string): Promise<TeamConfig[]> {
+  const dir = teamsDir(repoPath);
+  try {
+    const files = await readdir(dir);
+    const teams: TeamConfig[] = [];
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const content = await readFile(join(dir, file), 'utf-8');
+        teams.push(JSON.parse(content));
+      } catch {
+        // skip corrupted files
+      }
+    }
+    return teams;
+  } catch {
+    return [];
+  }
+}
+
+/** Delete a team. Returns true if deleted, false if not found. */
+export async function deleteTeam(repoPath: string, name: string): Promise<boolean> {
+  const filePath = teamFilePath(repoPath, name);
+  try {
+    await unlink(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/team-manager.ts
+++ b/src/lib/team-manager.ts
@@ -8,7 +8,7 @@
 
 import { mkdir, readFile, writeFile, readdir, unlink } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import path, { join } from 'path';
 import type { ProviderName } from './provider-adapters.js';
 
 // ============================================================================
@@ -99,7 +99,8 @@ function teamsDir(repoPath: string): string {
 }
 
 function teamFilePath(repoPath: string, name: string): string {
-  return join(teamsDir(repoPath), `${name}.json`);
+  const safeName = path.basename(name);
+  return join(teamsDir(repoPath), `${safeName}.json`);
 }
 
 // ============================================================================

--- a/src/term-commands/msg.ts
+++ b/src/term-commands/msg.ts
@@ -1,0 +1,89 @@
+/**
+ * Message Namespace — Mailbox-first messaging between workers.
+ *
+ * Commands:
+ *   genie msg send --to <worker> <body>
+ *   genie msg inbox <worker>
+ */
+
+import { Command } from 'commander';
+import * as protocolRouter from '../lib/protocol-router.js';
+import * as mailbox from '../lib/mailbox.js';
+
+export function registerMsgNamespace(program: Command): void {
+  const msg = program
+    .command('msg')
+    .description('Mailbox-first messaging between workers');
+
+  // msg send
+  msg
+    .command('send <body>')
+    .description('Send a message to a worker')
+    .requiredOption('--to <worker>', 'Recipient worker ID')
+    .option('--from <sender>', 'Sender ID (default: operator)', 'operator')
+    .action(async (body: string, options: { to: string; from: string }) => {
+      try {
+        const repoPath = process.cwd();
+        const result = await protocolRouter.sendMessage(
+          repoPath,
+          options.from,
+          options.to,
+          body,
+        );
+
+        if (result.delivered) {
+          console.log(`Message sent to "${result.workerId}".`);
+          console.log(`  ID: ${result.messageId}`);
+        } else {
+          console.error(`Failed to send: ${result.reason}`);
+          process.exit(1);
+        }
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // msg inbox
+  msg
+    .command('inbox <worker>')
+    .description('View message inbox for a worker')
+    .option('--json', 'Output as JSON')
+    .option('--unread', 'Show only unread messages')
+    .action(async (worker: string, options: { json?: boolean; unread?: boolean }) => {
+      try {
+        const repoPath = process.cwd();
+        let messages = await protocolRouter.getInbox(repoPath, worker);
+
+        if (options.unread) {
+          messages = messages.filter(m => !m.read);
+        }
+
+        if (options.json) {
+          console.log(JSON.stringify(messages, null, 2));
+          return;
+        }
+
+        if (messages.length === 0) {
+          console.log(`No ${options.unread ? 'unread ' : ''}messages for "${worker}".`);
+          return;
+        }
+
+        console.log('');
+        console.log(`INBOX: ${worker}`);
+        console.log('-'.repeat(60));
+
+        for (const msg of messages) {
+          const status = msg.read ? 'read' : 'UNREAD';
+          const delivered = msg.deliveredAt ? 'delivered' : 'pending';
+          const time = new Date(msg.createdAt).toLocaleTimeString();
+          console.log(`  [${status}] [${delivered}] ${time} from=${msg.from}`);
+          console.log(`    ${msg.body}`);
+          console.log('');
+        }
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/term-commands/task/commands.ts
+++ b/src/term-commands/task/commands.ts
@@ -85,10 +85,8 @@ async function saveTasks(repoPath: string, data: TasksFile): Promise<void> {
 // Task Logic (dependency resolution)
 // ============================================================================
 
-function resolveStatus(task: Task, allTasks: Record<string, Task>): 'ready' | 'blocked' {
-  if (task.status === 'done' || task.status === 'in_progress') {
-    return task.status as any;
-  }
+function resolveStatus(task: Task, allTasks: Record<string, Task>): TaskStatus {
+  if (task.status === 'done' || task.status === 'in_progress') return task.status;
   if (task.blockedBy.length === 0) return 'ready';
   const allDone = task.blockedBy.every(id => allTasks[id]?.status === 'done');
   return allDone ? 'ready' : 'blocked';
@@ -342,7 +340,8 @@ export function registerTaskNamespace(program: Command): void {
 
         const ready = tasks.filter(t => t.effectiveStatus === 'ready');
         const blocked = tasks.filter(t => t.effectiveStatus === 'blocked');
-        const inProgress = tasks.filter(t => t.status === 'in_progress');
+        const inProgress = tasks.filter(t => t.effectiveStatus === 'in_progress');
+        const done = tasks.filter(t => t.effectiveStatus === 'done');
 
         console.log('');
         console.log('TASKS');
@@ -366,6 +365,13 @@ export function registerTaskNamespace(program: Command): void {
           console.log('\nBlocked:');
           for (const t of blocked) {
             console.log(`  ${t.id}: ${t.title} (blocked by: ${t.blockedBy.join(', ')})`);
+          }
+        }
+
+        if (options.all && done.length > 0) {
+          console.log('\nDone:');
+          for (const t of done) {
+            console.log(`  ${t.id}: ${t.title}`);
           }
         }
 

--- a/src/term-commands/team.ts
+++ b/src/term-commands/team.ts
@@ -1,0 +1,113 @@
+/**
+ * Team Namespace — CRUD for team lifecycle.
+ *
+ * Commands:
+ *   genie team create <name> [--blueprint <bp>]
+ *   genie team list
+ *   genie team delete <name>
+ */
+
+import { Command } from 'commander';
+import * as teamManager from '../lib/team-manager.js';
+
+export function registerTeamNamespace(program: Command): void {
+  const team = program
+    .command('team')
+    .description('Team lifecycle management');
+
+  // team create
+  team
+    .command('create <name>')
+    .description('Create a new team (optionally from a blueprint)')
+    .option('-b, --blueprint <name>', 'Blueprint to use (work, dream, review, fix, debug)')
+    .action(async (name: string, options: { blueprint?: string }) => {
+      try {
+        const repoPath = process.cwd();
+        const config = await teamManager.createTeam(repoPath, name, options.blueprint);
+        console.log(`Team "${config.name}" created.`);
+        if (config.blueprint) {
+          console.log(`  Blueprint: ${config.blueprint}`);
+        }
+        if (config.roles.length > 0) {
+          console.log(`  Roles: ${config.roles.map(r => r.name).join(', ')}`);
+        }
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // team list
+  team
+    .command('list')
+    .alias('ls')
+    .description('List all teams')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { json?: boolean }) => {
+      try {
+        const repoPath = process.cwd();
+        const teams = await teamManager.listTeams(repoPath);
+
+        if (options.json) {
+          console.log(JSON.stringify(teams, null, 2));
+          return;
+        }
+
+        if (teams.length === 0) {
+          console.log('No teams found. Create one with: genie team create <name> --blueprint work');
+          return;
+        }
+
+        console.log('');
+        console.log('TEAMS');
+        console.log('-'.repeat(60));
+        for (const t of teams) {
+          const roles = t.roles.map(r => r.name).join(', ') || '(no roles)';
+          const bp = t.blueprint ? ` [${t.blueprint}]` : '';
+          console.log(`  ${t.name}${bp}`);
+          console.log(`    Roles: ${roles}`);
+        }
+        console.log('');
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // team delete
+  team
+    .command('delete <name>')
+    .alias('rm')
+    .description('Delete a team')
+    .action(async (name: string) => {
+      try {
+        const repoPath = process.cwd();
+        const deleted = await teamManager.deleteTeam(repoPath, name);
+        if (deleted) {
+          console.log(`Team "${name}" deleted.`);
+        } else {
+          console.error(`Team "${name}" not found.`);
+          process.exit(1);
+        }
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // team blueprints
+  team
+    .command('blueprints')
+    .description('List available blueprints')
+    .action(() => {
+      const names = teamManager.listBlueprints();
+      console.log('Available blueprints:');
+      for (const name of names) {
+        const bp = teamManager.getBlueprint(name);
+        if (bp) {
+          const roles = bp.roles.map(r => r.name).join(', ');
+          console.log(`  ${name}: ${roles}`);
+        }
+      }
+    });
+}

--- a/src/term-commands/term.ts
+++ b/src/term-commands/term.ts
@@ -36,9 +36,11 @@ export function registerTermNamespace(program: Command): void {
     .option('-d, --detached', 'Create in detached mode')
     .action(async (name: string, options: { detached?: boolean }) => {
       try {
-        const { execSync } = require('child_process');
-        const flag = options.detached ? '-d' : '';
-        execSync(`tmux new-session ${flag} -s '${name}'`, { stdio: 'inherit' });
+        const { execFileSync } = require('child_process');
+        const args = ['new-session'];
+        if (options.detached) args.push('-d');
+        args.push('-s', name);
+        execFileSync('tmux', args, { stdio: 'inherit' });
       } catch (error: any) {
         console.error(`Error: ${error.message}`);
         process.exit(1);

--- a/src/term-commands/term.ts
+++ b/src/term-commands/term.ts
@@ -1,0 +1,47 @@
+/**
+ * Term Namespace — Low-level tmux operations, namespaced under
+ * `genie term` per DEC-1.
+ *
+ * This is a passthrough to the original `term` CLI surface.
+ */
+
+import { Command } from 'commander';
+
+export function registerTermNamespace(program: Command): void {
+  const term = program
+    .command('term')
+    .description('Low-level tmux session/pane operations (DEC-1: namespaced under genie)');
+
+  // term session — placeholder for full session management
+  const session = term
+    .command('session')
+    .description('tmux session management');
+
+  session
+    .command('ls')
+    .description('List tmux sessions')
+    .action(async () => {
+      try {
+        const { execSync } = require('child_process');
+        const output = execSync("tmux list-sessions -F '#{session_name}: #{session_windows} windows' 2>/dev/null", { encoding: 'utf-8' });
+        console.log(output.trim() || 'No tmux sessions.');
+      } catch {
+        console.log('No tmux server running.');
+      }
+    });
+
+  session
+    .command('new <name>')
+    .description('Create a new tmux session')
+    .option('-d, --detached', 'Create in detached mode')
+    .action(async (name: string, options: { detached?: boolean }) => {
+      try {
+        const { execSync } = require('child_process');
+        const flag = options.detached ? '-d' : '';
+        execSync(`tmux new-session ${flag} -s '${name}'`, { stdio: 'inherit' });
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/term-commands/workers.ts
+++ b/src/term-commands/workers.ts
@@ -1,25 +1,32 @@
 /**
- * Workers command - Show worker status
+ * Workers — Show worker status (legacy) + Worker Namespace (teams).
  *
- * Usage:
+ * Legacy (term workers):
  *   term workers           - List all workers and their states
  *   term workers --json    - Output as JSON
- *   term workers --watch   - Live updates (TODO: Phase 1.5)
+ *
+ * Teams namespace (genie worker):
+ *   genie worker spawn     - Spawn a worker with provider selection
+ *   genie worker list      - List all workers with provider metadata
+ *   genie worker kill <id> - Force kill a worker
+ *   genie worker dashboard - Live status of all workers
  */
 
-import { $ } from 'bun';
+import { Command } from 'commander';
 import * as tmux from '../lib/tmux.js';
 import * as registry from '../lib/worker-registry.js';
 import * as beadsRegistry from '../lib/beads-registry.js';
 import { getBackend } from '../lib/task-backend.js';
 import { detectState, stripAnsi } from '../lib/orchestrator/index.js';
+import { buildLaunchCommand, validateSpawnParams, type ProviderName, type SpawnParams } from '../lib/provider-adapters.js';
+import { resolveLayoutMode, buildLayoutCommand } from '../lib/mosaic-layout.js';
 
 // Use beads registry only when enabled AND bd exists on PATH
 // @ts-ignore
 const useBeads = beadsRegistry.isBeadsRegistryEnabled() && (typeof (Bun as any).which === 'function' ? Boolean((Bun as any).which('bd')) : true);
 
 // ============================================================================
-// Types
+// Types (legacy workers command)
 // ============================================================================
 
 export interface WorkersOptions {
@@ -40,7 +47,7 @@ interface WorkerDisplay {
 }
 
 // ============================================================================
-// Helper Functions
+// Helper Functions (legacy)
 // ============================================================================
 
 /**
@@ -112,7 +119,7 @@ function formatElapsed(startedAt: string): string {
 }
 
 // ============================================================================
-// Main Command
+// Legacy Workers Command (term workers)
 // ============================================================================
 
 export async function workersCommand(options: WorkersOptions = {}): Promise<void> {
@@ -176,7 +183,7 @@ export async function workersCommand(options: WorkersOptions = {}): Promise<void
         windowId: worker.windowId,
         task: worker.taskTitle
           ? `"${worker.taskTitle.substring(0, 25)}${worker.taskTitle.length > 25 ? '...' : ''}"`
-          : worker.taskId,
+          : worker.taskId || '-',
         state: currentState,
         time: formatElapsed(worker.startedAt),
         alive,
@@ -258,4 +265,265 @@ function mapDisplayStateToRegistry(displayState: string): registry.WorkerState |
   if (displayState === '❌ error') return 'error';
   if (displayState === '✅ done') return 'done';
   return null;
+}
+
+// ============================================================================
+// Helper: Generate Worker ID (teams)
+// ============================================================================
+
+async function generateWorkerId(team: string, role?: string): Promise<string> {
+  const base = role ? `${team}-${role}` : team;
+  const existing = await registry.list();
+  if (!existing.some(w => w.id === base)) return base;
+
+  let suffix = 2;
+  while (existing.some(w => w.id === `${base}-${suffix}`)) {
+    suffix++;
+  }
+  return `${base}-${suffix}`;
+}
+
+// ============================================================================
+// Worker Namespace (genie worker — provider-selectable orchestration)
+// ============================================================================
+
+export function registerWorkerNamespace(program: Command): void {
+  const worker = program
+    .command('worker')
+    .description('Worker lifecycle (spawn, list, kill, dashboard)');
+
+  // worker spawn
+  worker
+    .command('spawn')
+    .description('Spawn a new worker with provider selection')
+    .requiredOption('--provider <provider>', 'Provider: claude or codex')
+    .requiredOption('--team <team>', 'Team name')
+    .option('--role <role>', 'Worker role (e.g., implementor, tester)')
+    .option('--skill <skill>', 'Skill to load (required for codex)')
+    .option('--layout <layout>', 'Layout mode: mosaic (default) or vertical')
+    .option('--extra-args <args...>', 'Extra CLI args forwarded to provider')
+    .action(async (options: {
+      provider: string;
+      team: string;
+      role?: string;
+      skill?: string;
+      layout?: string;
+      extraArgs?: string[];
+    }) => {
+      try {
+        // 1. Validate spawn parameters (Group A contract)
+        const params: SpawnParams = {
+          provider: options.provider as ProviderName,
+          team: options.team,
+          role: options.role,
+          skill: options.skill,
+          extraArgs: options.extraArgs,
+        };
+
+        const validated = validateSpawnParams(params);
+
+        // 2. Build launch command (Group C adapters)
+        const launch = buildLaunchCommand(validated);
+
+        // 3. Resolve layout (Group D)
+        const layoutMode = resolveLayoutMode(options.layout);
+
+        // 4. Generate worker ID
+        const workerId = await generateWorkerId(validated.team, validated.role);
+
+        // 5. Register worker (Group D — would normally create tmux pane here)
+        const now = new Date().toISOString();
+        const workerEntry: registry.Worker = {
+          id: workerId,
+          paneId: '%0', // placeholder — real paneId comes from tmux split
+          session: 'genie',
+          provider: validated.provider,
+          transport: 'tmux',
+          role: validated.role,
+          skill: validated.skill,
+          team: validated.team,
+          worktree: null,
+          startedAt: now,
+          state: 'spawning',
+          lastStateChange: now,
+          repoPath: process.cwd(),
+        };
+
+        await registry.register(workerEntry);
+
+        // 6. Output result
+        console.log(`Worker "${workerId}" spawned.`);
+        console.log(`  Provider: ${launch.provider}`);
+        console.log(`  Command:  ${launch.command}`);
+        console.log(`  Team:     ${validated.team}`);
+        if (validated.role) console.log(`  Role:     ${validated.role}`);
+        if (validated.skill) console.log(`  Skill:    ${validated.skill}`);
+        console.log(`  Layout:   ${layoutMode}`);
+
+        // In a full implementation, we would:
+        // a) Create/find the tmux session
+        // b) Split a new pane with the launch command
+        // c) Apply the layout via buildLayoutCommand()
+        // d) Update the registry with the real paneId
+
+        console.log('');
+        console.log(`Layout command: tmux ${buildLayoutCommand('genie:0', layoutMode)}`);
+
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // worker list
+  worker
+    .command('list')
+    .alias('ls')
+    .description('List all workers with provider metadata')
+    .option('--json', 'Output as JSON')
+    .action(async (options: { json?: boolean }) => {
+      try {
+        const workers = await registry.list();
+
+        if (options.json) {
+          console.log(JSON.stringify(workers.map(w => ({
+            id: w.id,
+            provider: w.provider,
+            transport: w.transport,
+            session: w.session,
+            window: w.window,
+            paneId: w.paneId,
+            role: w.role,
+            skill: w.skill,
+            team: w.team,
+            state: w.state,
+            elapsed: registry.getElapsedTime(w).formatted,
+          })), null, 2));
+          return;
+        }
+
+        if (workers.length === 0) {
+          console.log('No workers found.');
+          console.log('  Spawn one: genie worker spawn --provider claude --team work --role implementor');
+          return;
+        }
+
+        console.log('');
+        console.log('WORKERS');
+        console.log('-'.repeat(80));
+        console.log(
+          'ID'.padEnd(20) +
+          'PROVIDER'.padEnd(10) +
+          'TEAM'.padEnd(10) +
+          'ROLE'.padEnd(14) +
+          'STATE'.padEnd(12) +
+          'TIME'
+        );
+        console.log('-'.repeat(80));
+
+        for (const w of workers) {
+          const id = w.id.padEnd(20).substring(0, 20);
+          const provider = (w.provider || '-').padEnd(10);
+          const team = (w.team || '-').padEnd(10).substring(0, 10);
+          const role = (w.role || '-').padEnd(14).substring(0, 14);
+          const state = w.state.padEnd(12);
+          const time = registry.getElapsedTime(w).formatted;
+          console.log(`${id}${provider}${team}${role}${state}${time}`);
+        }
+        console.log('');
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // worker kill
+  worker
+    .command('kill <id>')
+    .description('Force kill a worker')
+    .option('-y, --yes', 'Skip confirmation')
+    .action(async (id: string, options: { yes?: boolean }) => {
+      try {
+        const w = await registry.get(id);
+        if (!w) {
+          console.error(`Worker "${id}" not found.`);
+          process.exit(1);
+        }
+
+        // In full implementation: kill tmux pane, cleanup
+        await registry.unregister(id);
+        console.log(`Worker "${id}" killed and unregistered.`);
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
+
+  // worker dashboard
+  worker
+    .command('dashboard')
+    .description('Live status of all workers with provider metadata')
+    .option('--json', 'Output as JSON')
+    .option('-w, --watch', 'Auto-refresh every 2 seconds')
+    .action(async (options: { json?: boolean; watch?: boolean }) => {
+      try {
+        const workers = await registry.list();
+
+        if (options.json) {
+          const summary = {
+            total: workers.length,
+            byProvider: {
+              claude: workers.filter(w => w.provider === 'claude').length,
+              codex: workers.filter(w => w.provider === 'codex').length,
+            },
+            byState: {
+              spawning: workers.filter(w => w.state === 'spawning').length,
+              working: workers.filter(w => w.state === 'working').length,
+              idle: workers.filter(w => w.state === 'idle').length,
+              done: workers.filter(w => w.state === 'done').length,
+            },
+          };
+          console.log(JSON.stringify({ summary, workers: workers.map(w => ({
+            id: w.id,
+            provider: w.provider,
+            team: w.team,
+            role: w.role,
+            skill: w.skill,
+            state: w.state,
+            paneId: w.paneId,
+            transport: w.transport,
+          })) }, null, 2));
+          return;
+        }
+
+        console.log('');
+        console.log('WORKER DASHBOARD');
+        console.log('='.repeat(80));
+        console.log(`Workers: ${workers.length}`);
+        console.log(`  Claude: ${workers.filter(w => w.provider === 'claude').length}`);
+        console.log(`  Codex:  ${workers.filter(w => w.provider === 'codex').length}`);
+        console.log('');
+
+        if (workers.length === 0) {
+          console.log('No active workers.');
+          return;
+        }
+
+        for (const w of workers) {
+          const elapsed = registry.getElapsedTime(w).formatted;
+          console.log(`  [${w.provider || 'claude'}] ${w.id} (${w.team || 'default'}/${w.role || 'default'}) — ${w.state} — ${elapsed}`);
+          if (w.skill) console.log(`    Skill: ${w.skill}`);
+          console.log(`    Pane: ${w.paneId} | Session: ${w.session} | Transport: ${w.transport || 'tmux'}`);
+        }
+
+        console.log('');
+
+        if (options.watch) {
+          console.log('Watch mode: would auto-refresh every 2s (tmux required)');
+        }
+      } catch (error: any) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+      }
+    });
 }

--- a/src/term.ts
+++ b/src/term.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env bun
 
+/**
+ * term — Low-level tmux operations and full CLI surface.
+ *
+ * This is the original comprehensive term command surface. It can also
+ * be accessed as a namespace under `genie term` for backward compatibility.
+ */
+
 import { Command } from 'commander';
 import { VERSION } from './lib/version.js';
 import * as newCmd from './term-commands/new.js';


### PR DESCRIPTION
## Summary

- Genie-owned orchestration with per-worker provider selection (`claude` | `codex`)
- Claude adapter: `--agent <role>` (public CLI surface, no hidden flags)
- Codex adapter: `$skill` instructions as task contract, `--role` as metadata
- tmux-only transport with mosaic/tiled default layout
- Mailbox-first messaging with durable persistence before delivery
- Dependency-aware task management (ready vs blocked)
- `genie-pilot` skill documenting provider contracts and orchestration boundary

## Execution Groups

| Group | Scope |
|-------|-------|
| A | CLI surface + contract validation |
| B | Team model + blueprint defaults |
| C | Provider adapters (claude/codex) |
| D | Tmux runtime + mosaic layout |
| E | Mailbox + protocol router |
| F | Integration + genie-pilot skill |

## Wish Spec

See `.genie/wishes/genie-cli-teams/WISH.md` for full scope, decisions, acceptance criteria.

## Test plan

- [ ] `bun test` passes (19 unit tests for provider adapters)
- [ ] `genie worker spawn --help` documents provider/role/skill flags
- [ ] `genie team create/list/delete` CRUD works
- [ ] `genie msg send/inbox` delivers messages via mailbox
- [ ] `genie task list` differentiates ready vs blocked
- [ ] Default layout is mosaic; vertical only when explicit