### PR TITLE
fix(ci): sync plugin package.json version + commit bump back to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -24,3 +26,12 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit version bump back to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json src/lib/version.ts plugins/automagik-genie/
+          git diff --staged --quiet && echo "No version changes to commit" || \
+            git commit -m "chore(version): bump to $(node -p 'require(\"./package.json\").version') [skip ci]" && \
+            git push origin main

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -10,6 +10,7 @@
  * - src/lib/version.ts
  * - plugins/automagik-genie/.claude-plugin/plugin.json (Claude Code)
  * - plugins/automagik-genie/openclaw.plugin.json (OpenClaw)
+ * - plugins/automagik-genie/package.json (smart-install version checks)
  */
 
 import { readFile, writeFile } from 'fs/promises';
@@ -96,6 +97,12 @@ async function main() {
   // 4. Update OpenClaw plugin manifest
   await updateJsonVersion(
     join(rootDir, 'plugins/automagik-genie/openclaw.plugin.json'),
+    version
+  );
+
+  // 5. Update plugin package.json (used by smart-install.js for version checks)
+  await updateJsonVersion(
+    join(rootDir, 'plugins/automagik-genie/package.json'),
     version
   );
 


### PR DESCRIPTION
## Summary
- Add `plugins/automagik-genie/package.json` to the version sync list in `scripts/version.ts`
- Add commit-back step to `publish.yml` so the version bump persists in the repo

## Problem
The `version.ts` script bumps 4 files during CI publish but **misses `plugins/automagik-genie/package.json`**. This is the file that:
1. `smart-install.js` reads via `getPluginVersion()` to decide if the genie CLI needs upgrading
2. Claude Code's plugin system reads to detect if the cache is stale

Since the version was never bumped in git, the plugin always showed the old version (`3.260224.1`) even after multiple publishes to npm (`3.260227.2`).

Additionally, the CI publish workflow ran the version bump but never committed the changes back — so ALL version files in the repo were stale after every publish.

## Test plan
- [ ] After merge + publish, `plugins/automagik-genie/package.json` version matches npm
- [ ] CI creates a `chore(version): bump to X.Y.Z [skip ci]` commit on main
- [ ] Claude Code `/plugin` update picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated version synchronization to repository during publish process.
  * Enhanced version consistency across plugin components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->