### PR TITLE
fix(ci): update publish workflow paths after plugin rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json src/lib/version.ts plugins/automagik-genie/
+          git add package.json src/lib/version.ts plugins/genie/ openclaw.plugin.json .claude-plugin/marketplace.json
           git diff --staged --quiet && echo "No version changes to commit" || \
             git commit -m "chore(version): bump to $(node -p 'require(\"./package.json\").version') [skip ci]" && \
             git push origin main

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -11,6 +11,7 @@
  * - plugins/genie/.claude-plugin/plugin.json (Claude Code)
  * - openclaw.plugin.json (OpenClaw — root level)
  * - plugins/genie/package.json (smart-install version checks)
+ * - .claude-plugin/marketplace.json (marketplace listing)
  */
 
 import { readFile, writeFile } from 'fs/promises';
@@ -105,6 +106,21 @@ async function main() {
     join(rootDir, 'plugins/genie/package.json'),
     version
   );
+
+  // 6. Update marketplace.json plugin version
+  const marketplacePath = join(rootDir, '.claude-plugin/marketplace.json');
+  if (existsSync(marketplacePath)) {
+    try {
+      const json = JSON.parse(await readFile(marketplacePath, 'utf-8'));
+      if (json.plugins?.[0]) {
+        json.plugins[0].version = version;
+      }
+      await writeFile(marketplacePath, JSON.stringify(json, null, 2) + '\n');
+      console.log(`  ✓ ${marketplacePath}`);
+    } catch (err) {
+      console.error(`  ✗ Failed: ${marketplacePath}`, err);
+    }
+  }
 
   console.log('\n✅ All versions synchronized');
 }


### PR DESCRIPTION
## Summary
- Fix `publish.yml` referencing old `plugins/automagik-genie/` path (→ `plugins/genie/`)
- Add `openclaw.plugin.json` and `.claude-plugin/marketplace.json` to the version bump `git add`
- Add marketplace.json auto-sync to `scripts/version.ts` (was missing from the rename PR)

## Context
PR #68 renamed `plugins/automagik-genie/` → `plugins/genie/` but missed the CI workflow reference, causing `fatal: pathspec 'plugins/automagik-genie/' did not match any files`.

## Test plan
- [ ] Merge to main triggers publish workflow
- [ ] `bun run build` runs version script successfully including marketplace.json
- [ ] Version bump commit includes all synced files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to include additional marketplace configuration files in release commits.
  * Enhanced the version update process to automatically synchronize version information with marketplace listing during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->