### PR TITLE
fix(install): openclaw plugin install uses package root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -710,16 +710,8 @@ offer_openclaw_plugin() {
         return 1
     fi
 
-    local plugin_dir="$PKG_DIR/plugins/genie"
-    local plugin_file="$plugin_dir/genie.ts"
-
-    if [[ ! -f "$plugin_dir/openclaw.plugin.json" ]]; then
-        warn "OpenClaw plugin manifest not found: $plugin_dir/openclaw.plugin.json"
-        return 1
-    fi
-
-    if [[ ! -f "$plugin_file" ]]; then
-        warn "OpenClaw plugin entrypoint not found: $plugin_file"
+    if [[ ! -f "$PKG_DIR/openclaw.plugin.json" ]]; then
+        warn "OpenClaw plugin manifest not found: $PKG_DIR/openclaw.plugin.json"
         return 1
     fi
 
@@ -727,14 +719,14 @@ offer_openclaw_plugin() {
     if confirm "Install Genie plugin for OpenClaw?"; then
         if $DEV_MODE; then
             log "Linking OpenClaw plugin (dev mode)..."
-            if openclaw plugins install -l "$plugin_dir"; then
+            if openclaw plugins install -l "$PKG_DIR"; then
                 success "OpenClaw plugin linked"
             else
                 warn "OpenClaw plugin link failed"
             fi
         else
             log "Installing OpenClaw plugin (copy mode)..."
-            if openclaw plugins install "$plugin_dir"; then
+            if openclaw plugins install "$PKG_DIR"; then
                 success "OpenClaw plugin installed"
             else
                 warn "OpenClaw plugin install failed"
@@ -778,7 +770,7 @@ To complete Genie setup, ask the user which integrations to enable:
 2. **OpenClaw Plugin** — Adds skills globally to OpenClaw
    Command:
 AGENT_EOF
-    printf '   openclaw plugins install %s/plugins/genie\n' "$PKG_DIR"
+    printf '   openclaw plugins install %s\n' "$PKG_DIR"
     cat <<'AGENT_EOF'
 
 3. **Codex/OpenCode Skills** — Adds skills to ~/.agents/skills/genie


### PR DESCRIPTION
## Summary

- `openclaw.plugin.json` lives at the package root (`$PKG_DIR/openclaw.plugin.json`), not inside `plugins/genie/`
- `offer_openclaw_plugin()` was passing `$PKG_DIR/plugins/genie` to `openclaw plugins install`, causing `package.json missing openclaw.extensions` error
- Fixed both `offer_openclaw_plugin()` and `output_agent_prompt()` to use `$PKG_DIR` directly

Found during live testing after PR #70 merge.

## Test plan

- [x] `openclaw plugins install $PKG_DIR` — installs successfully
- [x] All 3 integrations verified working (Claude Code, OpenClaw, Codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined OpenClaw plugin installation process with improved path validation
  * Updated installation command format for better consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->